### PR TITLE
Fix navigation and API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn.lock
 # Environment
 .env
 .env.*
+!.env.example

--- a/App.js
+++ b/App.js
@@ -58,10 +58,47 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <NavigationContainer>
           <Stack.Navigator initialRouteName="SplashScreen" screenOptions={{ headerShown: false }}>
-            {/* ...all previous screens... */}
+            <Stack.Screen name="SplashScreen" component={SplashScreen} />
+            <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+            <Stack.Screen name="AgeVerification" component={AgeVerification} />
+            <Stack.Screen name="Login" component={LoginScreen} />
+            <Stack.Screen name="SignUp" component={SignUpScreen} />
+            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
+            <Stack.Screen name="StoreSelection" component={StoreSelection} />
+            <Stack.Screen name="HomeScreen" component={HomeScreen} />
+            <Stack.Screen name="ShopScreen" component={ShopScreen} />
+            <Stack.Screen name="ProductDetails" component={ProductDetailsScreen} />
+            <Stack.Screen name="CartScreen" component={CartScreen} />
+            <Stack.Screen name="Checkout" component={CheckoutScreen} />
+            <Stack.Screen name="OrderConfirmation" component={OrderConfirmationScreen} />
+            <Stack.Screen name="OrderTracking" component={OrderTrackingScreen} />
+            <Stack.Screen name="OrderHistory" component={OrderHistoryScreen} />
+            <Stack.Screen name="OrderDetails" component={OrderDetailsScreen} />
+            <Stack.Screen name="StoreLocator" component={StoreLocatorScreen} />
+            <Stack.Screen name="StoreDetails" component={StoreDetailsScreen} />
+            <Stack.Screen name="Profile" component={ProfileScreen} />
+            <Stack.Screen name="EditProfile" component={EditProfileScreen} />
+            <Stack.Screen name="Favorites" component={FavoritesScreen} />
+            <Stack.Screen name="SavedAddresses" component={SavedAddressesScreen} />
+            <Stack.Screen name="AddAddress" component={AddAddressScreen} />
+            <Stack.Screen name="EditAddress" component={EditAddressScreen} />
+            <Stack.Screen name="SavedPayments" component={SavedPaymentsScreen} />
+            <Stack.Screen name="AddPayment" component={AddPaymentScreen} />
+            <Stack.Screen name="EditPayment" component={EditPaymentScreen} />
+            <Stack.Screen name="LoyaltyProgram" component={LoyaltyProgramDetailsScreen} />
+            <Stack.Screen name="Notifications" component={NotificationSettingsScreen} />
+            <Stack.Screen name="PrivacySettings" component={PrivacySettingsScreen} />
+            <Stack.Screen name="AppSettings" component={AppSettingsScreen} />
+            <Stack.Screen name="HelpFAQ" component={HelpFAQScreen} />
+            <Stack.Screen name="ContactUs" component={ContactUsScreen} />
+            <Stack.Screen name="EducationalGreenhouse" component={EducationalGreenhouseScreen} />
+            <Stack.Screen name="ArticleDetail" component={ArticleDetailScreen} />
+            <Stack.Screen name="CommunityGarden" component={CommunityGardenScreen} />
+            <Stack.Screen name="ConciergeChat" component={ConciergeChatScreen} />
             <Stack.Screen name="DataTransparency" component={DataTransparencyScreen} />
             <Stack.Screen name="AccessibilitySettings" component={AccessibilitySettingsScreen} />
             <Stack.Screen name="Awards" component={AwardsScreen} />
+            <Stack.Screen name="Legal" component={LegalScreen} />
           </Stack.Navigator>
         </NavigationContainer>
       </QueryClientProvider>

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ PORT=3000
 
 DATABASE_URL=your-postgres-url
 
+Frontend (/.env):
+
+EXPO_PUBLIC_API_BASE_URL=http://localhost:3000
+
 🧪 Testing & Quality
 
 Lint:npm run lint (ESLint)

--- a/src/api/phase4Client.ts
+++ b/src/api/phase4Client.ts
@@ -2,7 +2,7 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { getAuthToken } from '../utils/auth';
 
-const BASE_URL = 'http://127.0.0.1:4010';
+const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:3000';
 
 function createPhase4Client(): AxiosInstance {
   const client = axios.create({


### PR DESCRIPTION
## Summary
- register every screen route in `App.js`
- use `EXPO_PUBLIC_API_BASE_URL` env var for phase4 client
- document API URL in README and provide `.env.example`
- allow `.env.example` in gitignore

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880c52568d8832c8782eac7632205ed