### PR TITLE
Add auth login endpoint

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -24,6 +24,37 @@ paths:
                     type: string
                     example: healthy
 
+  /auth/login:
+    post:
+      summary: User login
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+              required:
+                - email
+                - password
+            example:
+              email: user@example.com
+              password: secret
+      responses:
+        '200':
+          description: JWT token
+          content:
+            application/json:
+              example:
+                token: <jwt>
+
   /awards:
     get:
       summary: List all awards

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/node';
 import './firebaseAdmin';
 import express, { Request, Response, NextFunction } from 'express';
 import { phase4Router } from './routes/phase4';
+import { authRouter } from './routes/auth';
 import SentryInit from './utils/sentry'; // triggers Sentry.init()
 
 const app = express();
@@ -15,6 +16,7 @@ app.get('/', (_req, res) => {
   res.json({ status: 'healthy' });
 });
 
+app.use('/', authRouter);
 app.use('/', phase4Router);
 
 // Type-safe Sentry error handler (always after all routes)

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { login } from '../controllers/authController';
+
+export const authRouter = Router();
+
+// POST /auth/login
+authRouter.post('/auth/login', login);


### PR DESCRIPTION
## Summary
- expose POST `/auth/login` route for user authentication
- mount the new auth router before the existing routes
- document the login endpoint in `openapi.yml`

## Testing
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_6880ff05bce4832c8b50a296989b519f