### PR TITLE
polish-auth-screens

### DIFF
--- a/src/screens/ForgotPasswordScreen.tsx
+++ b/src/screens/ForgotPasswordScreen.tsx
@@ -18,6 +18,8 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/types';
 import { ThemeContext } from '../context/ThemeContext';
 import { hapticLight, hapticMedium } from '../utils/haptic';
+import { SUPPORT_EMAIL } from '../constants/links';
+import * as Linking from 'expo-linking';
 
 // Enable LayoutAnimation on Android
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -32,6 +34,7 @@ export default function ForgotPasswordScreen() {
     useContext(ThemeContext);
 
   const [email, setEmail] = useState('');
+  const [focused, setFocused] = useState<boolean>(false);
 
   // Animate on mount
   useEffect(() => {
@@ -83,7 +86,12 @@ export default function ForgotPasswordScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: bgColor }]}>
       <View style={[styles.header, { borderBottomColor: jarsSecondary }]}>
-        <Pressable onPress={handleBack}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go Back"
+          onPress={handleBack}
+          style={({ pressed }) => pressed && { transform: [{ scale: 0.95 }] }}
+        >
           <ChevronLeft color={jarsPrimary} size={24} />
         </Pressable>
         <Text style={[styles.headerTitle, { color: jarsPrimary }]}>Forgot Password</Text>
@@ -95,26 +103,45 @@ export default function ForgotPasswordScreen() {
         <Text style={[styles.prompt, { color: jarsPrimary }]}>
           Enter your email address and we’ll send you a reset link.
         </Text>
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel="Contact Support"
+          onPress={() => Linking.openURL(`mailto:${SUPPORT_EMAIL}`)}
+          style={({ pressed }) => pressed && { transform: [{ scale: 0.95 }] }}
+        >
+          <Text style={[styles.supportLink, { color: jarsPrimary }]}>Need help? Contact support</Text>
+        </Pressable>
         <TextInput
           style={[
             styles.input,
             {
-              borderColor: jarsSecondary,
+              borderColor: focused ? jarsPrimary : jarsSecondary,
               color: jarsPrimary,
               backgroundColor: '#FFF',
             },
           ]}
           placeholder="you@example.com"
-          placeholderTextColor={jarsSecondary}
+          placeholderTextColor="#9CA3AF"
           keyboardType="email-address"
           value={email}
           onChangeText={t => {
             hapticLight();
             setEmail(t);
           }}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          accessibilityLabel="Email"
+          accessibilityRole="text"
         />
         <Pressable
-          style={[styles.submitBtn, { backgroundColor: jarsPrimary }, glowStyle]}
+          accessibilityRole="button"
+          accessibilityLabel="Send Reset Link"
+          style={({ pressed }) => [
+            styles.submitBtn,
+            { backgroundColor: jarsPrimary },
+            glowStyle,
+            pressed && { transform: [{ scale: 0.95 }] },
+          ]}
           onPress={onSubmit}
         >
           <Text style={styles.submitText}>Send Reset Link</Text>
@@ -133,7 +160,7 @@ const styles = StyleSheet.create({
     padding: 16,
     borderBottomWidth: 1,
   },
-  headerTitle: { fontSize: 20, fontWeight: '600' },
+  headerTitle: { fontSize: 24, fontWeight: '600' },
   content: { flex: 1, padding: 16 },
   prompt: {
     fontSize: 16,
@@ -158,5 +185,11 @@ const styles = StyleSheet.create({
     color: '#FFF',
     fontSize: 16,
     fontWeight: '600',
+  },
+  supportLink: {
+    fontSize: 14,
+    marginBottom: 16,
+    textAlign: 'center',
+    textDecorationLine: 'underline',
   },
 });

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -40,6 +40,7 @@ export default function LoginScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [focused, setFocused] = useState<string | null>(null);
 
   useEffect(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -78,6 +79,7 @@ export default function LoginScreen() {
     try {
       setLoading(true);
       setError(null);
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
       await signIn(email, password);
       logEvent('login_success', {});
       hapticMedium();
@@ -85,6 +87,7 @@ export default function LoginScreen() {
     } catch (err: any) {
       logEvent('login_failure', { message: err.message });
       hapticHeavy();
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
       setError(err.message);
     } finally {
       setLoading(false);
@@ -95,11 +98,14 @@ export default function LoginScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: bgColor }]}>
       <View style={styles.header}>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go Back"
           onPress={() => {
             hapticLight();
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
             navigation.goBack();
           }}
+          style={({ pressed }) => pressed && { transform: [{ scale: 0.95 }] }}
         >
           <ChevronLeft color={jarsPrimary} size={24} />
         </Pressable>
@@ -109,22 +115,43 @@ export default function LoginScreen() {
 
       <View style={styles.form}>
         <TextInput
-          style={[styles.input, { borderColor: jarsSecondary, color: jarsPrimary }]}
+          style={[
+            styles.input,
+            {
+              borderColor: focused === 'email' ? jarsPrimary : jarsSecondary,
+              color: jarsPrimary,
+            },
+          ]}
           placeholder="Email"
-          placeholderTextColor={jarsSecondary}
+          placeholderTextColor="#9CA3AF"
           keyboardType="email-address"
           autoCapitalize="none"
           value={email}
           onChangeText={setEmail}
+          onFocus={() => setFocused('email')}
+          onBlur={() => setFocused(null)}
+          accessibilityLabel="Email"
+          accessibilityRole="text"
         />
         <View style={styles.passwordRow}>
           <TextInput
-            style={[styles.input, { flex: 1, borderColor: jarsSecondary, color: jarsPrimary }]}
+            style={[
+              styles.input,
+              {
+                flex: 1,
+                borderColor: focused === 'password' ? jarsPrimary : jarsSecondary,
+                color: jarsPrimary,
+              },
+            ]}
             placeholder="Password"
-            placeholderTextColor={jarsSecondary}
+            placeholderTextColor="#9CA3AF"
             secureTextEntry={!showPassword}
             value={password}
             onChangeText={setPassword}
+            onFocus={() => setFocused('password')}
+            onBlur={() => setFocused(null)}
+            accessibilityLabel="Password"
+            accessibilityRole="text"
           />
           <Pressable onPress={() => setShowPassword(!showPassword)} style={styles.eyeBtn}>
             {showPassword ? <EyeOff color={jarsSecondary} size={20} /> : <Eye color={jarsSecondary} size={20} />}
@@ -134,17 +161,27 @@ export default function LoginScreen() {
         {error && <Text style={[styles.error, { color: 'red' }]}>{error}</Text>}
 
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Forgot Password"
           onPress={() => {
             hapticLight();
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
             navigation.navigate('ForgotPassword');
           }}
+          style={({ pressed }) => pressed && { transform: [{ scale: 0.95 }] }}
         >
           <Text style={[styles.link, { color: jarsPrimary }]}>Forgot Password?</Text>
         </Pressable>
 
         <Pressable
-          style={[styles.button, { backgroundColor: jarsPrimary }, glowStyle]}
+          accessibilityRole="button"
+          accessibilityLabel="Log In"
+          style={({ pressed }) => [
+            styles.button,
+            { backgroundColor: jarsPrimary },
+            glowStyle,
+            pressed && { transform: [{ scale: 0.95 }] },
+          ]}
           onPress={handleLogin}
           disabled={loading}
         >
@@ -156,17 +193,30 @@ export default function LoginScreen() {
         </Pressable>
 
         <View style={styles.footer}>
-          <Text style={[styles.disclaimer, { color: jarsSecondary }]}>
-            By logging in you agree to our
-          </Text>
-          <Pressable
-            onPress={() => {
-              hapticLight();
-              navigation.navigate('Legal');
-            }}
-          >
-            <Text style={[styles.linkText, { color: jarsPrimary }]}>Terms & Privacy</Text>
-          </Pressable>
+          <Text style={[styles.disclaimer, { color: jarsSecondary }]}>By logging in you agree to our</Text>
+          <View style={styles.legalRow}>
+            <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Terms and Conditions"
+              onPress={() => {
+                hapticLight();
+                navigation.navigate('Legal');
+              }}
+            >
+              <Text style={[styles.linkText, { color: jarsPrimary }]}>Terms &amp; Conditions</Text>
+            </Pressable>
+            <Text style={[styles.disclaimer, { color: jarsSecondary }]}> and </Text>
+            <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Privacy Policy"
+              onPress={() => {
+                hapticLight();
+                navigation.navigate('Legal');
+              }}
+            >
+              <Text style={[styles.linkText, { color: jarsPrimary }]}>Privacy Policy</Text>
+            </Pressable>
+          </View>
         </View>
       </View>
     </SafeAreaView>
@@ -202,4 +252,5 @@ const styles = StyleSheet.create({
   },
   disclaimer: { fontSize: 12, textAlign: 'center', marginBottom: 4 },
   linkText: { fontSize: 12, fontWeight: '600', textDecorationLine: 'underline' },
+  legalRow: { flexDirection: 'row', alignItems: 'center' },
 });

--- a/src/screens/OTPScreen.tsx
+++ b/src/screens/OTPScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { SafeAreaView, View, Text, TextInput, StyleSheet, Pressable } from 'react-native';
+import { SafeAreaView, View, Text, TextInput, StyleSheet, Pressable, LayoutAnimation } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
@@ -15,6 +15,7 @@ export default function OTPScreen() {
   const [code, setCode] = useState(Array(6).fill(''));
   const [timer, setTimer] = useState(60);
   const inputs: Array<TextInput | null> = [];
+  const [focused, setFocused] = useState<number | null>(null);
 
   useEffect(() => {
     const t = setInterval(() => setTimer(s => (s > 0 ? s - 1 : 0)), 1000);
@@ -51,31 +52,52 @@ export default function OTPScreen() {
           <TextInput
             key={i}
             ref={ref => (inputs[i] = ref)}
-            style={styles.input}
+            style={[
+              styles.input,
+              { borderColor: focused === i ? '#2E5D46' : '#ccc' },
+            ]}
             keyboardType="number-pad"
             maxLength={1}
             value={d}
             onChangeText={v => handleChange(i, v)}
+            onFocus={() => setFocused(i)}
+            onBlur={() => setFocused(null)}
+            accessibilityLabel={`Digit ${i + 1}`}
+            accessibilityRole="text"
           />
         ))}
       </View>
-      <Pressable style={styles.verifyBtn} onPress={handleSubmit}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Verify Code"
+        style={({ pressed }) => [
+          styles.verifyBtn,
+          pressed && { transform: [{ scale: 0.95 }] },
+        ]}
+        onPress={handleSubmit}
+      >
         <Text style={styles.verifyText}>Verify</Text>
       </Pressable>
       {timer === 0 ? (
-        <Pressable onPress={() => setTimer(60)}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Resend Code"
+          onPress={() => setTimer(60)}
+          style={({ pressed }) => pressed && { transform: [{ scale: 0.95 }] }}
+        >
           <Text style={styles.resend}>Resend code</Text>
         </Pressable>
       ) : (
         <Text style={styles.countdown}>Resend in {timer}s</Text>
       )}
+      <Text style={styles.disclaimer}>By verifying your identity you agree to our Terms &amp; Conditions and Privacy Policy.</Text>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
-  title: { fontSize: 22, marginBottom: 16, fontWeight: '600' },
+  title: { fontSize: 24, marginBottom: 16, fontWeight: '600' },
   row: { flexDirection: 'row', justifyContent: 'space-between', width: '80%', marginBottom: 24 },
   input: {
     borderWidth: 1,
@@ -96,4 +118,5 @@ const styles = StyleSheet.create({
   verifyText: { color: '#FFF', fontWeight: '600' },
   resend: { color: '#2E5D46', marginTop: 8 },
   countdown: { marginTop: 8, color: '#555' },
+  disclaimer: { marginTop: 16, fontSize: 12, textAlign: 'center', color: '#555' },
 });

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -41,6 +41,7 @@ export default function SignUpScreen() {
   const [confirm, setConfirm] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [optIn, setOptIn] = useState(false);
+  const [focused, setFocused] = useState<string | null>(null);
 
   useEffect(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -94,39 +95,80 @@ export default function SignUpScreen() {
       <Text style={[styles.title, { color: jarsPrimary }]}>Create Account</Text>
 
       <TextInput
-        style={[styles.input, { borderColor: jarsSecondary, color: jarsPrimary }]}
+        style={[
+          styles.input,
+          {
+            borderColor: focused === 'name' ? jarsPrimary : jarsSecondary,
+            color: jarsPrimary,
+          },
+        ]}
         placeholder="Full Name"
-        placeholderTextColor={jarsSecondary}
+        placeholderTextColor="#9CA3AF"
         value={name}
         onChangeText={setName}
+        onFocus={() => setFocused('name')}
+        onBlur={() => setFocused(null)}
+        accessibilityLabel="Full Name"
+        accessibilityRole="text"
       />
 
       <TextInput
-        style={[styles.input, { borderColor: jarsSecondary, color: jarsPrimary }]}
+        style={[
+          styles.input,
+          {
+            borderColor: focused === 'email' ? jarsPrimary : jarsSecondary,
+            color: jarsPrimary,
+          },
+        ]}
         placeholder="Email"
-        placeholderTextColor={jarsSecondary}
+        placeholderTextColor="#9CA3AF"
         keyboardType="email-address"
         value={email}
         onChangeText={setEmail}
+        onFocus={() => setFocused('email')}
+        onBlur={() => setFocused(null)}
+        accessibilityLabel="Email"
+        accessibilityRole="text"
       />
 
       <TextInput
-        style={[styles.input, { borderColor: jarsSecondary, color: jarsPrimary }]}
+        style={[
+          styles.input,
+          {
+            borderColor: focused === 'phone' ? jarsPrimary : jarsSecondary,
+            color: jarsPrimary,
+          },
+        ]}
         placeholder="Phone"
-        placeholderTextColor={jarsSecondary}
+        placeholderTextColor="#9CA3AF"
         keyboardType="phone-pad"
         value={phone}
         onChangeText={setPhone}
+        onFocus={() => setFocused('phone')}
+        onBlur={() => setFocused(null)}
+        accessibilityLabel="Phone"
+        accessibilityRole="tel"
       />
 
       <View style={styles.passwordRow}>
         <TextInput
-          style={[styles.input, { flex: 1, borderColor: jarsSecondary, color: jarsPrimary }]}
+          style={[
+            styles.input,
+            {
+              flex: 1,
+              borderColor: focused === 'password' ? jarsPrimary : jarsSecondary,
+              color: jarsPrimary,
+            },
+          ]}
           placeholder="Password"
-          placeholderTextColor={jarsSecondary}
+          placeholderTextColor="#9CA3AF"
           secureTextEntry={!showPassword}
           value={password}
           onChangeText={setPassword}
+          onFocus={() => setFocused('password')}
+          onBlur={() => setFocused(null)}
+          accessibilityLabel="Password"
+          accessibilityRole="text"
         />
         <Pressable onPress={() => setShowPassword(!showPassword)} style={styles.eyeBtn}>
           {showPassword ? <EyeOff color={jarsSecondary} size={20} /> : <Eye color={jarsSecondary} size={20} />}
@@ -136,12 +178,23 @@ export default function SignUpScreen() {
 
       <View style={styles.passwordRow}>
         <TextInput
-          style={[styles.input, { flex: 1, borderColor: jarsSecondary, color: jarsPrimary }]}
+          style={[
+            styles.input,
+            {
+              flex: 1,
+              borderColor: focused === 'confirm' ? jarsPrimary : jarsSecondary,
+              color: jarsPrimary,
+            },
+          ]}
           placeholder="Confirm Password"
-          placeholderTextColor={jarsSecondary}
+          placeholderTextColor="#9CA3AF"
           secureTextEntry={!showPassword}
           value={confirm}
           onChangeText={setConfirm}
+          onFocus={() => setFocused('confirm')}
+          onBlur={() => setFocused(null)}
+          accessibilityLabel="Confirm Password"
+          accessibilityRole="text"
         />
         <Pressable onPress={() => setShowPassword(!showPassword)} style={styles.eyeBtn}>
           {showPassword ? <EyeOff color={jarsSecondary} size={20} /> : <Eye color={jarsSecondary} size={20} />}
@@ -154,34 +207,57 @@ export default function SignUpScreen() {
       </Pressable>
 
       <Pressable
-        style={[styles.button, { backgroundColor: jarsPrimary }, glowStyle]}
+        accessibilityRole="button"
+        accessibilityLabel="Sign Up"
+        style={({ pressed }) => [
+          styles.button,
+          { backgroundColor: jarsPrimary },
+          glowStyle,
+          pressed && { transform: [{ scale: 0.95 }] },
+        ]}
         onPress={handleSignUp}
       >
         <Text style={styles.buttonText}>Sign Up</Text>
       </Pressable>
 
       <View style={styles.policy}>
-        <Text style={[styles.disclaimer, { color: jarsSecondary }]}>
-          By creating an account you agree to our
-        </Text>
-        <Pressable
-          onPress={() => {
-            hapticLight();
-            navigation.navigate('Legal');
-          }}
-        >
-          <Text style={[styles.linkText, { color: jarsPrimary }]}>Terms & Privacy</Text>
-        </Pressable>
+        <Text style={[styles.disclaimer, { color: jarsSecondary }]}>By creating an account you agree to our</Text>
+        <View style={styles.legalRow}>
+          <Pressable
+            accessibilityRole="link"
+            accessibilityLabel="Terms and Conditions"
+            onPress={() => {
+              hapticLight();
+              navigation.navigate('Legal');
+            }}
+          >
+            <Text style={[styles.linkText, { color: jarsPrimary }]}>Terms &amp; Conditions</Text>
+          </Pressable>
+          <Text style={[styles.disclaimer, { color: jarsSecondary }]}> and </Text>
+          <Pressable
+            accessibilityRole="link"
+            accessibilityLabel="Privacy Policy"
+            onPress={() => {
+              hapticLight();
+              navigation.navigate('Legal');
+            }}
+          >
+            <Text style={[styles.linkText, { color: jarsPrimary }]}>Privacy Policy</Text>
+          </Pressable>
+        </View>
       </View>
 
       <View style={styles.footer}>
         <Text style={[styles.footerText, { color: jarsSecondary }]}>Already have an account?</Text>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Log In"
           onPress={() => {
             hapticLight();
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
             navigation.replace('Login');
           }}
+          style={({ pressed }) => pressed && { transform: [{ scale: 0.95 }] }}
         >
           <Text style={[styles.linkText, { color: jarsPrimary }]}>Log In</Text>
         </Pressable>
@@ -197,7 +273,7 @@ const styles = StyleSheet.create({
     padding: 24,
   },
   title: {
-    fontSize: 28,
+    fontSize: 24,
     fontWeight: '700',
     textAlign: 'center',
     marginBottom: 32,
@@ -253,5 +329,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 16,
   },
+  legalRow: { flexDirection: 'row', alignItems: 'center' },
   disclaimer: { fontSize: 12, textAlign: 'center', marginBottom: 4 },
 });


### PR DESCRIPTION
## Summary
- finalize sign-up footer legal links and styling
- polish login screen styles and accessibility
- update OTP screen with verification disclaimer
- add support contact link to forgot password flow

## Testing
- `./setup.sh` *(fails: EUSAGE; then installed packages successfully)*
- `npm run lint` *(fails to pass lint)*
- `npx tsc --noEmit` *(fails to typecheck)*

------
https://chatgpt.com/codex/tasks/task_e_688516f89278832c824401195891ef52