### PR TITLE
SecureStore with AsyncStorage fallback

### DIFF
--- a/e2e/secureAuth.test.ts
+++ b/e2e/secureAuth.test.ts
@@ -1,0 +1,17 @@
+import { device, element, by, expect } from 'detox';
+
+describe('Secure Auth Flow', () => {
+  it('should persist token securely', async () => {
+    await device.launchApp({ delete: true });
+    await element(by.id('login-button')).tap();
+    await element(by.id('email-input')).typeText('test@jars.com');
+    await element(by.id('password-input')).typeText('Test1234');
+    await element(by.id('submit-button')).tap();
+    await expect(element(by.id('home-screen'))).toBeVisible();
+  });
+
+  it('should retrieve secure data after app restart', async () => {
+    await device.reloadReactNative();
+    await expect(element(by.id('home-screen'))).toBeVisible();
+  });
+});

--- a/src/utils/secureStorage.ts
+++ b/src/utils/secureStorage.ts
@@ -1,0 +1,28 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+
+export async function saveSecure(key: string, value: string) {
+  try {
+    await SecureStore.setItemAsync(key, value);
+  } catch (err) {
+    await AsyncStorage.setItem(key, value);
+  }
+}
+
+export async function getSecure(key: string): Promise<string | null> {
+  try {
+    const value = await SecureStore.getItemAsync(key);
+    if (value != null) return value;
+    return await AsyncStorage.getItem(key);
+  } catch {
+    return await AsyncStorage.getItem(key);
+  }
+}
+
+export async function deleteSecure(key: string) {
+  try {
+    await SecureStore.deleteItemAsync(key);
+  } catch {
+    await AsyncStorage.removeItem(key);
+  }
+}


### PR DESCRIPTION
## Summary
- add secureStorage utils for storing data using SecureStore with AsyncStorage fallback
- secure AuthContext token loading with expiry checks and fallback storage
- save user name/email in SecureStore
- add Detox test harness for secure auth flow

## Testing
- `./setup.sh` *(fails: npm ci can only install packages when lock file in sync)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68851bab294c832c93c9012bc73f1547