### PR TITLE
Add biometric toggle and onboarding slide

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import { RootStackParamList } from './src/navigation/types';
 import { ThemeProvider } from './src/context/ThemeContext';
 import { LoyaltyProvider } from './src/context/LoyaltyContext';
 import { StoreProvider } from './src/context/StoreContext';
+import { SettingsProvider } from './src/context/SettingsContext';
 import * as SecureStore from 'expo-secure-store';
 
 import SplashScreenWrapper from './src/screens/SplashScreenWrapper';
@@ -83,7 +84,8 @@ export default function App() {
     <StoreProvider>
       <LoyaltyProvider>
         <ThemeProvider>
-          <QueryClientProvider client={queryClient}>
+          <SettingsProvider>
+            <QueryClientProvider client={queryClient}>
           <NavigationContainer>
             <Stack.Navigator initialRouteName={initialRoute} screenOptions={{ headerShown: false }}>
               <Stack.Screen name="SplashScreen" component={SplashScreenWrapper} />
@@ -141,6 +143,7 @@ export default function App() {
             </Stack.Navigator>
           </NavigationContainer>
         </QueryClientProvider>
+          </SettingsProvider>
       </ThemeProvider>
     </LoyaltyProvider>
   </StoreProvider>

--- a/assets/illustrations/illustration-biometrics-secure.svg
+++ b/assets/illustrations/illustration-biometrics-secure.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#E5F5EA" stroke="#2E5D46" stroke-width="4"/>
+  <path d="M50 30a15 15 0 0 1 15 15v5a5 5 0 0 1-10 0v-5a5 5 0 0 0-10 0v10a5 5 0 0 1-10 0v-10a15 15 0 0 1 15-15z" fill="#2E5D46"/>
+</svg>

--- a/src/components/OnboardingSlide.tsx
+++ b/src/components/OnboardingSlide.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Image } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
+import AnimatedPulseGlow from './AnimatedPulseGlow';
 
 interface Props {
   headline: string;
   benefitText: string;
+  illustration?: any;
   isActive: boolean;
 }
 
-export default function OnboardingSlide({ headline, benefitText }: Props) {
+export default function OnboardingSlide({ headline, benefitText, illustration }: Props) {
   return (
     <View style={styles.container} accessibilityRole="text" accessibilityLabel={headline}>
+      {illustration && (
+        <Animated.View entering={FadeIn.duration(500)} style={styles.illustrationWrap}>
+          <AnimatedPulseGlow />
+          <Image source={illustration} style={styles.illustration} />
+        </Animated.View>
+      )}
       <Text style={styles.headline}>{headline}</Text>
       <Text style={styles.text}>{benefitText}</Text>
     </View>
@@ -20,4 +29,6 @@ const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 16 },
   headline: { fontSize: 24, fontWeight: '700', textAlign: 'center', marginBottom: 8 },
   text: { fontSize: 16, textAlign: 'center' },
+  illustrationWrap: { alignItems: 'center', justifyContent: 'center', marginBottom: 16 },
+  illustration: { width: 120, height: 120, resizeMode: 'contain', position: 'absolute' },
 });

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { saveSecure, getSecure } from '../utils/secureStorage';
+
+interface SettingsContextState {
+  biometricEnabled: boolean;
+  setBiometricEnabled: (value: boolean) => Promise<void>;
+}
+
+const SettingsContext = createContext<SettingsContextState>({
+  biometricEnabled: true,
+  setBiometricEnabled: async () => {},
+});
+
+export const SettingsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [biometricEnabled, setBiometricEnabledState] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await getSecure('useBiometricAuth');
+      if (stored === 'false') setBiometricEnabledState(false);
+    })();
+  }, []);
+
+  const setBiometricEnabled = async (value: boolean) => {
+    setBiometricEnabledState(value);
+    await saveSecure('useBiometricAuth', String(value));
+  };
+
+  return (
+    <SettingsContext.Provider value={{ biometricEnabled, setBiometricEnabled }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => useContext(SettingsContext);

--- a/src/screens/AppSettingsScreen.tsx
+++ b/src/screens/AppSettingsScreen.tsx
@@ -17,7 +17,7 @@ import { useNavigation } from '@react-navigation/native';
 import { ThemeContext } from '../context/ThemeContext';
 import { hapticLight } from '../utils/haptic';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
+import { useSettings } from '../context/SettingsContext';
 
 // Enable LayoutAnimation on Android
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -30,15 +30,12 @@ export default function AppSettingsScreen() {
   const [darkMode, setDarkMode] = useState(false);
   const [visitAlerts, setVisitAlerts] = useState(false);
   const [personalOffers, setPersonalOffers] = useState(false);
-  const [useBiometrics, setUseBiometrics] = useState(true);
+  const { biometricEnabled, setBiometricEnabled } = useSettings();
 
   useEffect(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     AsyncStorage.getItem('visitAlerts').then(v => setVisitAlerts(v === 'true'));
     AsyncStorage.getItem('personalOffers').then(v => setPersonalOffers(v === 'true'));
-    SecureStore.getItemAsync('useBiometricAuth').then(v => {
-      if (v === 'false') setUseBiometrics(false);
-    });
   }, []);
 
   const handleBack = () => {
@@ -70,8 +67,7 @@ export default function AppSettingsScreen() {
   const toggleBiometric = (val: boolean) => {
     hapticLight();
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setUseBiometrics(val);
-    SecureStore.setItemAsync('useBiometricAuth', String(val));
+    setBiometricEnabled(val);
   };
 
   const bgColor =
@@ -122,11 +118,11 @@ export default function AppSettingsScreen() {
           />
         </View>
 
-        {/* Biometric Unlock */}
+        <Text style={[styles.section, { color: jarsSecondary }]}>Privacy &amp; Security</Text>
         <View style={[styles.row, { borderBottomColor: jarsSecondary }]}>
-          <Text style={[styles.label, { color: jarsPrimary }]}>Biometric Unlock</Text>
+          <Text style={[styles.label, { color: jarsPrimary }]}>Enable Face ID / Touch ID</Text>
           <Switch
-            value={useBiometrics}
+            value={biometricEnabled}
             onValueChange={toggleBiometric}
             trackColor={{ false: '#EEEEEE', true: jarsSecondary }}
             thumbColor="#FFFFFF"
@@ -179,4 +175,5 @@ const styles = StyleSheet.create({
   label: { fontSize: 16 },
   value: { fontSize: 16 },
   subLabel: { fontSize: 14, marginTop: 4 },
+  section: { fontSize: 14, fontWeight: '600', marginTop: 24, marginBottom: 8 },
 });

--- a/src/screens/OnboardingPager.tsx
+++ b/src/screens/OnboardingPager.tsx
@@ -25,6 +25,11 @@ const slides = [
     headline: 'Best Value',
     benefitText: 'Great deals every day',
   },
+  {
+    headline: 'Safe & Seamless Access',
+    benefitText: 'Log in securely with Face ID, Touch ID, or a PIN – your privacy, protected.',
+    illustration: require('../assets/illustrations/illustration-biometrics-secure.svg'),
+  },
 ];
 
 export default function OnboardingPager() {
@@ -51,6 +56,7 @@ export default function OnboardingPager() {
             <OnboardingSlide
               headline={s.headline}
               benefitText={s.benefitText}
+              illustration={s.illustration}
               isActive={i === index}
             />
             {i === slides.length - 1 && (


### PR DESCRIPTION
## Summary
- create `SettingsContext` for app preferences
- show Face ID/Touch ID toggle in AppSettings
- wrap app with `SettingsProvider`
- highlight secure biometrics in onboarding flow
- add fingerprint illustration asset

## Testing
- `npm run lint` *(fails: prettier violations)*
- `npx tsc --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688525ee6d04832c971bcd79f9ec1ce0