### PR TITLE
Integrate CMS content with offline support

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import { LoyaltyProvider } from './src/context/LoyaltyContext';
 import { StoreProvider } from './src/context/StoreContext';
 import { SettingsProvider } from './src/context/SettingsContext';
 import { CMSPreviewProvider } from './src/context/CMSPreviewContext';
+import OfflineNotice from './src/components/OfflineNotice';
 import * as SecureStore from 'expo-secure-store';
 
 import SplashScreenWrapper from './src/screens/SplashScreenWrapper';
@@ -88,6 +89,7 @@ export default function App() {
           <SettingsProvider>
             <CMSPreviewProvider>
               <QueryClientProvider client={queryClient}>
+          <OfflineNotice />
           <NavigationContainer>
             <Stack.Navigator initialRouteName={initialRoute} screenOptions={{ headerShown: false }}>
               <Stack.Screen name="SplashScreen" component={SplashScreenWrapper} />

--- a/src/components/ArticlePreviewCard.tsx
+++ b/src/components/ArticlePreviewCard.tsx
@@ -4,7 +4,7 @@ import type { CMSArticle } from '../types/cms';
 import { hapticLight } from '../utils/haptic';
 
 interface Props {
-  article: CMSArticle;
+  article: CMSArticle & { isPreview?: boolean };
   onPress: () => void;
 }
 
@@ -12,6 +12,11 @@ export default function ArticlePreviewCard({ article, onPress }: Props) {
   const snippet = String(article.body).slice(0, 80);
   return (
     <Pressable style={styles.card} onPress={() => { hapticLight(); onPress(); }}>
+      {article.isPreview && (
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>Preview</Text>
+        </View>
+      )}
       <Text style={styles.title}>{article.title}</Text>
       <Text style={styles.snippet}>{snippet}...</Text>
     </Pressable>
@@ -24,6 +29,15 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderColor: '#eee',
   },
+  badge: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#FF9800',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    marginBottom: 4,
+  },
+  badgeText: { color: '#fff', fontSize: 10 },
   title: { fontSize: 16, fontWeight: '600', marginBottom: 4 },
   snippet: { color: '#555' },
 });

--- a/src/components/ArticleSkeletonCard.tsx
+++ b/src/components/ArticleSkeletonCard.tsx
@@ -1,0 +1,1 @@
+export { default } from './SkeletonArticleCard';

--- a/src/components/FAQSkeleton.tsx
+++ b/src/components/FAQSkeleton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, StyleSheet, Animated, Easing } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+export default function FAQSkeleton() {
+  const translateX = React.useRef(new Animated.Value(-100)).current;
+
+  React.useEffect(() => {
+    Animated.loop(
+      Animated.timing(translateX, {
+        toValue: 300,
+        duration: 1000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      })
+    ).start();
+  }, [translateX]);
+
+  return (
+    <View style={styles.item}>\
+      <Animated.View style={[StyleSheet.absoluteFill, { transform: [{ translateX }] }]}>\
+        <LinearGradient colors={['transparent', '#e0e0e0', 'transparent']} style={StyleSheet.absoluteFill} start={{x:0,y:0}} end={{x:1,y:0}} />\
+      </Animated.View>\
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: { height: 60, marginBottom: 12, backgroundColor: '#ccc', overflow: 'hidden' },
+});

--- a/src/components/OfflineNotice.tsx
+++ b/src/components/OfflineNotice.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useNetInfo } from '@react-native-community/netinfo';
+
+export default function OfflineNotice() {
+  const netInfo = useNetInfo();
+  if (netInfo.isConnected === false) {
+    return (
+      <View style={styles.banner}>
+        <Text style={styles.text}>Offline Mode</Text>
+      </View>
+    );
+  }
+  return null;
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    backgroundColor: '#f44336',
+    paddingVertical: 4,
+    alignItems: 'center',
+  },
+  text: { color: '#fff', fontSize: 12 },
+});

--- a/src/components/useSkeletonText.tsx
+++ b/src/components/useSkeletonText.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, StyleSheet, Animated, Easing } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+export default function useSkeletonText(width: number, height: number) {
+  const translateX = React.useRef(new Animated.Value(-100)).current;
+
+  React.useEffect(() => {
+    Animated.loop(
+      Animated.timing(translateX, {
+        toValue: 300,
+        duration: 1000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      })
+    ).start();
+  }, [translateX]);
+
+  return (
+    <View style={[styles.box, { width, height }]}>\
+      <Animated.View style={[StyleSheet.absoluteFill, { transform: [{ translateX }] }]}>\
+        <LinearGradient colors={['transparent', '#e0e0e0', 'transparent']} style={StyleSheet.absoluteFill} start={{x:0,y:0}} end={{x:1,y:0}} />\
+      </Animated.View>\
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: { backgroundColor: '#ccc', overflow: 'hidden' },
+});

--- a/src/hooks/useArticleBySlug.ts
+++ b/src/hooks/useArticleBySlug.ts
@@ -1,16 +1,37 @@
 import { useQuery } from '@tanstack/react-query';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { cmsClient } from '../api/cmsClient';
 import type { CMSArticle } from '../types/cms';
 
-async function fetchArticle(slug: string) {
-  const res = await cmsClient.get<CMSArticle>(`/api/greenhouse/articles/${slug}`);
-  return res.data;
+async function fetchArticle(slug: string, preview: boolean) {
+  const cacheKey = `cms:article:${slug}${preview ? ':preview' : ''}`;
+  try {
+    const res = await cmsClient.get<CMSArticle>(`/content/articles/${slug}`, {
+      headers: preview ? { 'X-Preview': 'true' } : undefined,
+    });
+    await AsyncStorage.setItem(cacheKey, JSON.stringify(res.data));
+    return res.data;
+  } catch (err) {
+    const cached = await AsyncStorage.getItem(cacheKey);
+    if (cached) return JSON.parse(cached) as CMSArticle;
+    throw err;
+  }
 }
 
+import NetInfo from '@react-native-community/netinfo';
+import { useCMSPreview } from '../context/CMSPreviewContext';
+
 export function useArticleBySlug(slug: string) {
+  const { preview } = useCMSPreview();
   return useQuery<CMSArticle, Error>({
-    queryKey: ['cmsArticle', slug],
-    queryFn: () => fetchArticle(slug),
+    queryKey: ['cmsArticle', slug, preview],
+    queryFn: async () => {
+      const state = await NetInfo.fetch();
+      if (!state.isConnected) {
+        return fetchArticle(slug, preview);
+      }
+      return fetchArticle(slug, preview);
+    },
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
     enabled: !!slug,

--- a/src/hooks/useArticles.ts
+++ b/src/hooks/useArticles.ts
@@ -1,6 +1,6 @@
 import type { CMSArticle } from '../types/cms';
 import { useCMSContent } from './useCMSContent';
 
-export function useArticles() {
-  return useCMSContent<CMSArticle[]>(['articles'], '/api/greenhouse/articles');
+export function useArticlesQuery() {
+  return useCMSContent<CMSArticle[]>(['articles'], '/content/articles');
 }

--- a/src/hooks/useCMSContent.ts
+++ b/src/hooks/useCMSContent.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import NetInfo from '@react-native-community/netinfo';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { cmsClient } from '../api/cmsClient';
 import { useCMSPreview } from '../context/CMSPreviewContext';
 
@@ -10,13 +11,29 @@ export function useCMSContent<T>(key: string[], path: string) {
     queryKey: [...key, preview],
     queryFn: async () => {
       const state = await NetInfo.fetch();
+      const cacheKey = `cms:${path}${preview ? ':preview' : ''}`;
+
       if (!state.isConnected) {
+        const cached = await AsyncStorage.getItem(cacheKey);
+        if (cached) {
+          return JSON.parse(cached) as T;
+        }
         throw new Error('Offline');
       }
-      const res = await cmsClient.get<T>(path, {
-        headers: preview ? { 'X-Preview': 'true' } : undefined,
-      });
-      return res.data;
+
+      try {
+        const res = await cmsClient.get<T>(path, {
+          headers: preview ? { 'X-Preview': 'true' } : undefined,
+        });
+        await AsyncStorage.setItem(cacheKey, JSON.stringify(res.data));
+        return res.data;
+      } catch (err) {
+        const cached = await AsyncStorage.getItem(cacheKey);
+        if (cached) {
+          return JSON.parse(cached) as T;
+        }
+        throw err;
+      }
     },
   });
 }

--- a/src/hooks/useFAQ.ts
+++ b/src/hooks/useFAQ.ts
@@ -1,6 +1,6 @@
 import type { FAQItem } from '../types/cmsExtra';
 import { useCMSContent } from './useCMSContent';
 
-export function useFAQ() {
-  return useCMSContent<FAQItem[]>(['faq'], '/api/content/faq');
+export function useFAQQuery() {
+  return useCMSContent<FAQItem[]>(['faq'], '/content/faq');
 }

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -1,0 +1,6 @@
+import type { ShopFilter } from '../types/cmsExtra';
+import { useCMSContent } from './useCMSContent';
+
+export function useFiltersQuery() {
+  return useCMSContent<ShopFilter[]>(['filters'], '/content/filters');
+}

--- a/src/hooks/useLegal.ts
+++ b/src/hooks/useLegal.ts
@@ -2,5 +2,5 @@ import type { LegalContent } from '../types/cmsExtra';
 import { useCMSContent } from './useCMSContent';
 
 export function useLegal() {
-  return useCMSContent<LegalContent>(['legal'], '/api/content/legal');
+  return useCMSContent<LegalContent>(['legal'], '/content/legal');
 }

--- a/src/screens/ArticleDetailScreen.tsx
+++ b/src/screens/ArticleDetailScreen.tsx
@@ -33,7 +33,7 @@ export default function ArticleDetailScreen() {
   const navigation = useNavigation<ArticleNavProp>();
   const route = useRoute<ArticleRouteProp>();
   const { slug } = route.params;
-  const { data, isLoading } = useArticleBySlug(slug);
+  const { data, isLoading, isError } = useArticleBySlug(slug);
 
   const { colorTemp, jarsPrimary, jarsSecondary, jarsBackground } = useContext(ThemeContext);
 
@@ -50,7 +50,7 @@ export default function ArticleDetailScreen() {
     navigation.goBack();
   };
 
-  if (isLoading || !data) {
+  if (isLoading) {
     return (
       <SafeAreaView
         style={[
@@ -59,6 +59,19 @@ export default function ArticleDetailScreen() {
         ]}
       >
         <ActivityIndicator />
+      </SafeAreaView>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <SafeAreaView
+        style={[
+          styles.container,
+          { backgroundColor: bgColor, justifyContent: 'center', alignItems: 'center' },
+        ]}
+      >
+        <Text>Unable to load article.</Text>
       </SafeAreaView>
     );
   }

--- a/src/screens/EducationalGreenhouseScreen.tsx
+++ b/src/screens/EducationalGreenhouseScreen.tsx
@@ -17,9 +17,9 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/types';
 import { ThemeContext } from '../context/ThemeContext';
 import { hapticLight } from '../utils/haptic';
-import { useArticles } from '../hooks/useArticles';
+import { useArticlesQuery } from '../hooks/useArticles';
 import ArticlePreviewCard from '../components/ArticlePreviewCard';
-import SkeletonArticleCard from '../components/SkeletonArticleCard';
+import ArticleSkeletonCard from '../components/ArticleSkeletonCard';
 import PreviewBadge from '../components/PreviewBadge';
 import { useCMSPreview } from '../context/CMSPreviewContext';
 
@@ -33,7 +33,7 @@ type EduNavProp = NativeStackNavigationProp<RootStackParamList, 'EducationalGree
 export default function EducationalGreenhouseScreen() {
   const navigation = useNavigation<EduNavProp>();
   const { colorTemp, jarsPrimary, jarsSecondary, jarsBackground } = useContext(ThemeContext);
-  const { data, isLoading, isError } = useArticles();
+  const { data, isLoading, isError } = useArticlesQuery();
   const { preview } = useCMSPreview();
 
   useEffect(() => {
@@ -70,9 +70,9 @@ export default function EducationalGreenhouseScreen() {
 
       {isLoading && (
         <View style={styles.list}>
-          <SkeletonArticleCard />
-          <SkeletonArticleCard />
-          <SkeletonArticleCard />
+          <ArticleSkeletonCard />
+          <ArticleSkeletonCard />
+          <ArticleSkeletonCard />
         </View>
       )}
       {isError && (

--- a/src/screens/HelpFAQScreen.tsx
+++ b/src/screens/HelpFAQScreen.tsx
@@ -15,7 +15,8 @@ import { ChevronLeft } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { ThemeContext } from '../context/ThemeContext';
 import { hapticLight } from '../utils/haptic';
-import { useFAQ } from '../hooks/useFAQ';
+import { useFAQQuery } from '../hooks/useFAQ';
+import FAQSkeleton from '../components/FAQSkeleton';
 import PreviewBadge from '../components/PreviewBadge';
 import { useCMSPreview } from '../context/CMSPreviewContext';
 
@@ -29,7 +30,7 @@ export default function HelpFAQScreen() {
   const navigation = useNavigation();
   const { colorTemp, jarsPrimary, jarsSecondary, jarsBackground } = useContext(ThemeContext);
   const [openIds, setOpenIds] = useState<string[]>([]);
-  const { data, isLoading, isError } = useFAQ();
+  const { data, isLoading, isError } = useFAQQuery();
   const { preview } = useCMSPreview();
 
   useEffect(() => {
@@ -53,8 +54,12 @@ export default function HelpFAQScreen() {
 
   if (isLoading) {
     return (
-      <SafeAreaView style={[styles.container, { justifyContent: 'center', alignItems: 'center', backgroundColor: bgColor }]}>
-        <Text>Loading...</Text>
+      <SafeAreaView
+        style={[styles.container, { justifyContent: 'center', alignItems: 'center', backgroundColor: bgColor }]}
+      >
+        <FAQSkeleton />
+        <FAQSkeleton />
+        <FAQSkeleton />
       </SafeAreaView>
     );
   }

--- a/src/screens/LegalScreen.tsx
+++ b/src/screens/LegalScreen.tsx
@@ -18,6 +18,7 @@ import type { RootStackParamList } from '../navigation/types';
 import { ThemeContext } from '../context/ThemeContext';
 import { hapticLight } from '../utils/haptic';
 import { useLegal } from '../hooks/useLegal';
+import useSkeletonText from '../components/useSkeletonText';
 import PreviewBadge from '../components/PreviewBadge';
 import { useCMSPreview } from '../context/CMSPreviewContext';
 
@@ -48,8 +49,12 @@ export default function LegalScreen() {
 
   if (isLoading) {
     return (
-      <SafeAreaView style={[styles.container, { justifyContent: 'center', alignItems: 'center', backgroundColor: bgColor }]}>\
-        <Text>Loading...</Text>
+      <SafeAreaView
+        style={[styles.container, { justifyContent: 'center', alignItems: 'center', backgroundColor: bgColor }]}
+      >
+        {useSkeletonText(200, 16)}
+        {useSkeletonText(260, 16)}
+        {useSkeletonText(220, 16)}
       </SafeAreaView>
     );
   }
@@ -75,11 +80,8 @@ export default function LegalScreen() {
       </View>
 
       <ScrollView contentContainerStyle={styles.scroll}>
-        <Text style={[styles.sectionTitle, { color: jarsPrimary }]}>Terms & Conditions</Text>
-        <Text style={[styles.bodyText, { color: jarsSecondary }]}>{data.terms}</Text>
-
-        <Text style={[styles.sectionTitle, { color: jarsPrimary }]}>Privacy Policy</Text>
-        <Text style={[styles.bodyText, { color: jarsSecondary }]}>{data.privacy}</Text>
+        <Text style={[styles.sectionTitle, { color: jarsPrimary }]}>{data.title}</Text>
+        <Text style={[styles.bodyText, { color: jarsSecondary }]}>{data.body}</Text>
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/screens/ShopScreen.tsx
+++ b/src/screens/ShopScreen.tsx
@@ -19,6 +19,8 @@ import type { RootStackParamList } from '../navigation/types';
 import { ThemeContext } from '../context/ThemeContext';
 import { TERPENES } from '../terpene_wheel/data/terpenes';
 import { hapticLight } from '../utils/haptic';
+import { useFiltersQuery } from '../hooks/useFilters';
+import useSkeletonText from '../components/useSkeletonText';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -52,6 +54,7 @@ export default function ShopScreen() {
   const navigation = useNavigation<ShopNavProp>();
   const { colorTemp, jarsPrimary, jarsSecondary, jarsBackground } = useContext(ThemeContext);
   const [products] = useState(sampleProducts);
+  const { data: filters, isLoading: filtersLoading } = useFiltersQuery();
 
   // animate on mount
   useEffect(() => {
@@ -90,6 +93,20 @@ export default function ShopScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: bgColor }]}>
+      <View style={styles.filterRow}>
+        {filtersLoading && (
+          <>
+            {useSkeletonText(60, 20)}
+            {useSkeletonText(80, 20)}
+          </>
+        )}
+        {!filtersLoading &&
+          filters?.map(f => (
+            <View key={f.id} style={[styles.filterChip, { borderColor: jarsPrimary }]}>\
+              <Text style={{ color: jarsPrimary }}>{f.label}</Text>
+            </View>
+          ))}
+      </View>
       <FlatList
         data={products}
         keyExtractor={item => item.id}
@@ -113,6 +130,15 @@ export default function ShopScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
+  filterRow: { flexDirection: 'row', flexWrap: 'wrap', padding: 16 },
+  filterChip: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginRight: 8,
+    marginBottom: 8,
+  },
   list: { padding: 16 },
   card: {
     width: CARD_WIDTH,

--- a/src/types/cmsExtra.ts
+++ b/src/types/cmsExtra.ts
@@ -5,6 +5,11 @@ export interface FAQItem {
 }
 
 export interface LegalContent {
-  terms: string;
-  privacy: string;
+  title: string;
+  body: string;
+}
+
+export interface ShopFilter {
+  id: string;
+  label: string;
 }


### PR DESCRIPTION
## Summary
- add offline caching layer in `useCMSContent`
- add skeleton loaders for legal text, FAQs, and articles
- fetch FAQs, articles, and legal info from new `/content` endpoints
- create offline notice banner
- show preview badge on article cards
- load dynamic shop filters

## Testing
- `./setup.sh`
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_688537026388832cb3c410931f96f4dd