### PR TITLE
Persist Cart State with Zustand + AsyncStorage

### DIFF
--- a/src/__tests__/cart/storePersistence.test.ts
+++ b/src/__tests__/cart/storePersistence.test.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useCartStore, hydrateCartStore } from '../../../stores/useCartStore';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+describe('cart store persistence', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    useCartStore.setState({ items: [] });
+  });
+
+  it('rehydrates items from AsyncStorage', async () => {
+    useCartStore.getState().addItem({ id: '1', name: 'Test', price: 10, quantity: 2 });
+    await new Promise(res => setTimeout(res, 0));
+    const stored = await AsyncStorage.getItem('cart');
+    jest.resetModules();
+    const AsyncStorage2 = require('@react-native-async-storage/async-storage');
+    if (stored) await AsyncStorage2.setItem('cart', stored);
+    const { useCartStore: rehydratedStore, hydrateCartStore: rehydrate } = require('../../../stores/useCartStore');
+    await rehydrate();
+    expect(rehydratedStore.getState().items).toEqual([
+      { id: '1', name: 'Test', price: 10, quantity: 2, available: true },
+    ]);
+  });
+});

--- a/src/hooks/useCartValidation.ts
+++ b/src/hooks/useCartValidation.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { phase4Client } from '../api/phase4Client';
+import { toast } from '../utils/toast';
+import { useCartStore, CartItem } from '../../stores/useCartStore';
+
+export function useCartValidation() {
+  const items = useCartStore(state => state.items);
+  const setItems = useCartStore(state => state.setItems);
+  const [validating, setValidating] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    async function run() {
+      const updated: CartItem[] = [];
+      for (const item of items) {
+        try {
+          const { data } = await phase4Client.get(`/products/${item.id}`);
+          const variant = item.variantId ? data.variants.find((v: any) => v.id === item.variantId) : undefined;
+          if (!variant || variant.stock <= 0) {
+            updated.push({ ...item, available: false });
+            toast(`${item.name} is no longer available`);
+          } else {
+            if (variant.price !== item.price) {
+              toast(`${item.name} price updated`);
+            }
+            updated.push({ ...item, price: variant.price, available: true });
+          }
+        } catch {
+          toast(`${item.name} was removed`);
+          // omit item -> removed from cart
+        }
+      }
+      if (mounted) {
+        setItems(updated);
+        setValidating(false);
+      }
+    }
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { validating };
+}

--- a/stores/useCartStore.ts
+++ b/stores/useCartStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+  variantId?: string;
+  available?: boolean;
+}
+
+interface CartState {
+  items: CartItem[];
+  addItem: (item: CartItem) => void;
+  updateQuantity: (id: string, quantity: number) => void;
+  removeItem: (id: string) => void;
+  setItems: (items: CartItem[]) => void;
+}
+
+export const useCartStore = create<CartState>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      addItem: item => {
+        const existing = get().items.find(i => i.id === item.id && i.variantId === item.variantId);
+        if (existing) {
+          set({
+            items: get().items.map(i =>
+              i === existing ? { ...i, quantity: i.quantity + item.quantity } : i,
+            ),
+          });
+        } else {
+          set({ items: [...get().items, { ...item, available: true }] });
+        }
+      },
+      updateQuantity: (id, quantity) =>
+        set({ items: get().items.map(i => (i.id === id ? { ...i, quantity } : i)) }),
+      removeItem: id => set({ items: get().items.filter(i => i.id !== id) }),
+      setItems: items => set({ items }),
+    }),
+    {
+      name: 'cart',
+      version: 1,
+      storage: createJSONStorage(() => AsyncStorage),
+      migrate: persisted => persisted as CartState,
+    },
+  ),
+);
+
+export const hydrateCartStore = () => useCartStore.persist.rehydrate();


### PR DESCRIPTION
## Summary
- use zustand persist with AsyncStorage for cart items
- validate cart items against product details and flag unavailable items
- add unit test covering cart state rehydration

## Testing
- `npx jest src/__tests__/cart/storePersistence.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6894e6567540832ca9158843538ce9e5