### PR TITLE
Add GitHub Actions CI Pipeline for Lint, Type Check, and Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jars Cannabis Mobile App
 
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions)
+
 A premium React Native mobile app for Jars Cannabis, designed to deliver an award-winning, legally compliant, and highly personalized cannabis shopping experience.
 
 ## 📱 Features (MVP)


### PR DESCRIPTION
## Summary
- add CI workflow to run lint, typecheck, and tests on push and pull requests
- show placeholder CI status badge in README

## Testing
- `npm run lint` *(fails: prettier/prettier violations and unused vars)*
- `npm run typecheck` *(fails: multiple TS errors and missing modules)*
- `npm test` *(fails: missing exports and modules, 9 failed test suites)*


------
https://chatgpt.com/codex/tasks/task_e_689513b89ac0832c96ac52357b1fb5e4