### PR TITLE
chore: install dev tools and AWS Amplify CLI

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,3 +3,6 @@ npm ci --legacy-peer-deps
 if [ -d backend ]; then
   (cd backend && npm ci --legacy-peer-deps)
 fi
+
+# install global development tools, including AWS Amplify CLI
+npm install -g expo-cli firebase-tools @aws-amplify/cli


### PR DESCRIPTION
## Summary
- install global dev tools (Expo CLI, Firebase tools, Amplify CLI) during setup

## Testing
- `./setup.sh` *(fails: npm warn Unknown env config "http-proxy"; process interrupted)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'aws-lambda', 'node', 'react', 'request', 'superagent'; missing 'expo/tsconfig.base')*

------
https://chatgpt.com/codex/tasks/task_e_689711d7877c832cbca116eb251006d8