### PR TITLE
test: expand deep link and banner coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+jest.mock('@aws-amplify/analytics', () => ({ record: jest.fn() }));
+jest.mock('aws-amplify', () => ({ Analytics: { record: jest.fn() } }));
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -1,0 +1,15 @@
+import type { StoreData } from '../@types/store';
+
+export const makeStore = (overrides: Partial<StoreData> = {}): StoreData => ({
+  id: '1',
+  name: 'Midtown',
+  slug: 'midtown',
+  latitude: 0,
+  longitude: 0,
+  address: '123 Main St',
+  city: 'Phoenix',
+  state: 'AZ',
+  zip: '85001',
+  phone: '555-555-5555',
+  ...overrides,
+});

--- a/src/__tests__/welcomeBanner.test.tsx
+++ b/src/__tests__/welcomeBanner.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import renderer, { act } from 'react-test-renderer';
 import WelcomeBanner from '../components/WelcomeBanner';
 import { LoyaltyContext } from '../context/LoyaltyContext';
-import { StoreProvider } from '../context/StoreContext';
+import { makeStore } from './testUtils';
+
+let preferredStore = makeStore();
+jest.mock('../context/StoreContext', () => ({
+  useStore: () => ({ preferredStore, setPreferredStore: jest.fn() }),
+}));
 
 jest.mock('react-native', () => ({
   View: ({ children }: any) => <div>{children}</div>,
@@ -15,16 +20,53 @@ jest.mock('expo-secure-store', () => ({
   deleteItemAsync: jest.fn(() => Promise.resolve()),
 }));
 
-it('shows loyalty banner callouts per tier', () => {
-  const tree = renderer.create(
-    <StoreProvider>
+beforeEach(() => {
+  preferredStore = makeStore();
+});
+
+it('shows default message when no promo', async () => {
+  preferredStore.promo = undefined;
+  let tree: renderer.ReactTestRenderer | undefined;
+  await act(async () => {
+    tree = renderer.create(
+      <LoyaltyContext.Provider
+        value={{ data: null, isLoading: false, isError: false, error: undefined }}
+      >
+        <WelcomeBanner />
+      </LoyaltyContext.Provider>
+    );
+  });
+  const span = tree!.root.findByType('span');
+  expect(span.children[0]).toBe('Welcome!');
+});
+
+it('shows store promo when available', async () => {
+  preferredStore = makeStore({ promo: '$10 Off Pickup Orders' });
+  let tree: renderer.ReactTestRenderer | undefined;
+  await act(async () => {
+    tree = renderer.create(
+      <LoyaltyContext.Provider
+        value={{ data: null, isLoading: false, isError: false, error: undefined }}
+      >
+        <WelcomeBanner />
+      </LoyaltyContext.Provider>
+    );
+  });
+  const span = tree!.root.findByType('span');
+  expect(span.children[0]).toBe(`${preferredStore.name} Exclusive: ${preferredStore.promo}`);
+});
+
+it('shows loyalty banner callouts per tier', async () => {
+  let tree: renderer.ReactTestRenderer | undefined;
+  await act(async () => {
+    tree = renderer.create(
       <LoyaltyContext.Provider
         value={{ data: { tier: 'Gold' }, isLoading: false, isError: false, error: undefined }}
       >
         <WelcomeBanner />
       </LoyaltyContext.Provider>
-    </StoreProvider>
-  );
-  const span = tree.root.findByType('span');
+    );
+  });
+  const span = tree!.root.findByType('span');
   expect(span.children[0]).toBe('Gold Tier Perk: Double Points This Week');
 });

--- a/src/components/WelcomeBanner.tsx
+++ b/src/components/WelcomeBanner.tsx
@@ -14,7 +14,7 @@ export default function WelcomeBanner() {
   if (loyaltyTier === 'Gold') {
     message = 'Gold Tier Perk: Double Points This Week';
   } else if (promo && preferredStore?.name) {
-    message = `${preferredStore.name} Exclusive: $10 Off Pickup Orders`;
+    message = `${preferredStore.name} Exclusive: ${promo}`;
   }
 
   return (


### PR DESCRIPTION
## Summary
- mock Amplify analytics globally and wire jest setup
- add makeStore() factory and update deep link & welcome banner tests
- handle optional promo and dynamic message in WelcomeBanner

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test src/__tests__/deepLink.test.tsx src/__tests__/welcomeBanner.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6897a969c388832c98afa33564401d0d