### PR TITLE
chore(ci): add local tsconfig base and update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,5 +30,55 @@ jobs:
           fi
       - run: npm ci
       - run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm i -g npm@$(node -p "require('./package.json').engines.npm")
+      - name: Verify Node.js and npm versions
+        run: |
+          EXPECTED_NODE="v$(cat .nvmrc)"
+          ACTUAL_NODE="$(node -v)"
+          if [ "$ACTUAL_NODE" != "$EXPECTED_NODE" ]; then
+            echo "Node version mismatch: expected $EXPECTED_NODE but got $ACTUAL_NODE"
+            exit 1
+          fi
+          EXPECTED_NPM=$(node -p "require('./package.json').engines.npm")
+          ACTUAL_NPM="$(npm -v)"
+          if [ "$ACTUAL_NPM" != "$EXPECTED_NPM" ]; then
+            echo "npm version mismatch: expected $EXPECTED_NPM but got $ACTUAL_NPM"
+            exit 1
+          fi
+      - run: npm ci
       - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm i -g npm@$(node -p "require('./package.json').engines.npm")
+      - name: Verify Node.js and npm versions
+        run: |
+          EXPECTED_NODE="v$(cat .nvmrc)"
+          ACTUAL_NODE="$(node -v)"
+          if [ "$ACTUAL_NODE" != "$EXPECTED_NODE" ]; then
+            echo "Node version mismatch: expected $EXPECTED_NODE but got $ACTUAL_NODE"
+            exit 1
+          fi
+          EXPECTED_NPM=$(node -p "require('./package.json').engines.npm")
+          ACTUAL_NPM="$(npm -v)"
+          if [ "$ACTUAL_NPM" != "$EXPECTED_NPM" ]; then
+            echo "npm version mismatch: expected $EXPECTED_NPM but got $ACTUAL_NPM"
+            exit 1
+          fi
+      - run: npm ci
       - run: npm test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,6 +79,7 @@ module.exports = [
       '.eslintrc.js',
       'jest.config.js',
       'eslint.config.js',
+      'package-lock.json',
     ],
   },
 ];

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Expo",
+
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "react-native",
+    "lib": ["DOM", "ESNext"],
+    "module": "preserve",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "customConditions": ["react-native"],
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "ESNext"
+  },
+
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo/tsconfig.base",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",


### PR DESCRIPTION
## Summary
- add Expo's tsconfig.base locally and extend from it
- run lint and typecheck jobs via `npm ci`
- ignore package-lock.json in eslint to avoid parse errors

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6897c0fbdfbc832c8c6474a6d422804d