### PR TITLE
Railway start wiring — Procfile + backend launcher + scripts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start:backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon --watch src --ext ts --exec \"ts-node --project tsconfig.json src/index.ts\"",
     "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "node start-prod.js",
     "mock": "prism mock openapi.yml --port 4000"
   },
   "keywords": [],

--- a/backend/start-prod.js
+++ b/backend/start-prod.js
@@ -1,0 +1,23 @@
+/**
+ * Minimal launcher for the compiled backend.
+ * Tries backend/dist/server/index.js, then backend/dist/index.js.
+ * Keeps process alive as long as the HTTP server runs.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const candidates = [
+  path.join(__dirname, 'dist', 'server', 'index.js'),
+  path.join(__dirname, 'dist', 'index.js'),
+];
+
+for (const p of candidates) {
+  if (fs.existsSync(p)) {
+    console.log('[start] launching', p);
+    require(p);
+    return;
+  }
+}
+
+console.error('[start] No backend entry found in dist/. Did you run `npm run build:backend`?');
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:web": "expo build:web",
     "vercel-build": "mkdir -p dist && echo '<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Placeholder</title></head><body></body></html>' > dist/index.html",
     "build:backend": "npm --prefix backend run build",
+    "start:backend": "npm --prefix backend run start",
     "build": "npm run build:backend",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
## Summary
- add Procfile to run backend via npm start:backend
- add backend launcher to locate compiled entry file
- wire up start scripts for backend in package.json files

## Testing
- `./setup.sh` *(fails: The `npm ci` command can only install with an existing package-lock.json...)*
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68990e40433c832c9a93fcd01776887d