### PR TITLE
feat(backend): add security middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,8 @@
         "dotenv": "^16.0.0",
         "express": "^4.18.2",
         "firebase-admin": "^11.0.0",
+        "helmet": "^7.0.0",
+        "jsonwebtoken": "^9.0.2",
         "module-alias": "^2.2.3",
         "openai": "^4.0.0",
         "prisma": "^4.16.2",
@@ -3170,6 +3172,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "mock": "prism mock openapi.yml --port 4000",
     "migrate": "prisma migrate deploy",
     "generate": "prisma generate",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "seed": "ts-node --transpile-only prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
@@ -32,7 +33,9 @@
     "openai": "^4.0.0",
     "prisma": "^4.16.2",
     "stripe": "^14.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",


### PR DESCRIPTION
## Summary
- add helmet and CORS setup in backend server
- expose database seed script and include jsonwebtoken dependency

## Testing
- `./setup.sh`
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689afdd2ca1c832cb9f9109e54b5917b