### PR TITLE
feat: add direct database url

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,8 +5,9 @@ binaryTargets = ["native", "rhel-openssl-1.1.x", "debian-openssl-1.1.x"]
 }
 
 datasource db {
-provider = "postgresql"
-url = env("DATABASE_URL")
+  provider = "postgresql"
+  url = env("DATABASE_URL")
+  directUrl = env("DIRECT_DATABASE_URL")
 }
 
 enum OrderStatus {


### PR DESCRIPTION
## Summary
- reference a direct database URL for Prisma

## Testing
- `./setup.sh` *(fails: ENOTEMPTY: directory not empty, rmdir '/workspace/jars-cannabis-mobile-app/node_modules/@prisma/client/scripts')*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'aws-lambda')*


------
https://chatgpt.com/codex/tasks/task_e_689b21ced1f0832ca0b1d12b3e88c3dd