### PR TITLE
feat: add firebase admin bootstrap

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Express + Firestore backend for JARS Phase 4",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=18.18 <19"
+    "node": ">=18 <=22"
   },
   "scripts": {
     "dev": "nodemon --watch src --ext ts --exec \"ts-node --project tsconfig.json src/index.ts\"",

--- a/backend/src/bootstrap/firebase-admin.ts
+++ b/backend/src/bootstrap/firebase-admin.ts
@@ -1,34 +1,34 @@
-export { initFirebase } from '../firebaseAdmin';
-
 import * as admin from 'firebase-admin';
 
-let app: admin.app.App | null = null;
+let appInstance: admin.app.App | null = null;
 
 function serviceAccountFromEnv(): admin.ServiceAccount {
-const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_BASE64;
-if (!b64) throw new Error('FIREBASE_SERVICE_ACCOUNT_BASE64 missing');
-const json = Buffer.from(b64, 'base64').toString('utf8');
-const svc = JSON.parse(json);
-if (typeof (svc as any).private_key !== 'string' || !(svc as any).private_key.includes('BEGIN PRIVATE KEY')) {
-throw new Error('service account JSON missing valid private_key');
-}
-return svc as admin.ServiceAccount;
-}
-
-export function initFirebase(): admin.app.App {
-if (app) return app;
-if (admin.apps.length) { app = admin.app(); return app; }
-app = admin.initializeApp({
-credential: admin.credential.cert(serviceAccountFromEnv()),
-storageBucket: `${process.env.FIREBASE_PROJECT_ID}.appspot.com`,
-});
-console.log('Firebase Admin initialized');
-return app;
+  const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_BASE64;
+  if (!b64) throw new Error('FIREBASE_SERVICE_ACCOUNT_BASE64 missing');
+  const json = Buffer.from(b64, 'base64').toString('utf8');
+  const svc = JSON.parse(json);
+  if (typeof (svc as any).private_key !== 'string' || !(svc as any).private_key.includes('BEGIN PRIVATE KEY')) {
+    throw new Error('service account JSON missing valid private_key');
+  }
+  return svc as admin.ServiceAccount;
 }
 
-export function getFirestore(): FirebaseFirestore.Firestore {
-if (!admin.apps.length) initFirebase();
-return admin.firestore();
-}
+export const initFirebase = (): admin.app.App => {
+  if (appInstance) return appInstance;
+  if (admin.apps.length) {
+    appInstance = admin.app();
+    return appInstance;
+  }
+  appInstance = admin.initializeApp({
+    credential: admin.credential.cert(serviceAccountFromEnv()),
+    storageBucket: `${process.env.FIREBASE_PROJECT_ID}.appspot.com`,
+  });
+  return appInstance;
+};
+
+export const getFirestore = (): admin.firestore.Firestore => {
+  if (!admin.apps.length) initFirebase();
+  return admin.firestore();
+};
 
 export { admin };


### PR DESCRIPTION
## Summary
- add firebase admin bootstrap with service account loader
- widen Node engine range up to version 22

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b9d0e1198832c8d08addc71954243