### PR TITLE
Pin Metro dependencies and add clean modules script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
+    "clean:modules": "rm -rf node_modules package-lock.json && npm cache verify",
     "fix:deps": "bash scripts/fix-dependencies.sh",
     "prepare": "husky install",
     "start": "expo start",
@@ -187,5 +188,15 @@
         ]
       }
     }
+  },
+  "overrides": {
+    "metro": "0.80.10",
+    "metro-config": "0.80.10",
+    "metro-core": "0.80.10",
+    "metro-runtime": "0.80.10",
+    "metro-resolver": "0.80.10",
+    "metro-source-map": "0.80.10",
+    "metro-cache": "0.80.10",
+    "metro-minify-terser": "0.80.10"
   }
 }


### PR DESCRIPTION
## Summary
- add clean:modules npm script for removing node_modules and cache
- pin Metro packages via npm overrides to 0.80.10

## Testing
- `npm run lint` (fails: 155 warnings)
- `npx tsc --noEmit` (fails: Cannot find module 'react-native')

------
https://chatgpt.com/codex/tasks/task_e_689ce19a0868832cbc1f21c2e6ebb440