### PR TITLE
chore: pin metro packages to 0.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,13 +190,13 @@
     }
   },
   "overrides": {
-    "metro": "0.80.10",
-    "metro-config": "0.80.10",
-    "metro-core": "0.80.10",
-    "metro-runtime": "0.80.10",
-    "metro-resolver": "0.80.10",
-    "metro-source-map": "0.80.10",
-    "metro-cache": "0.80.10",
-    "metro-minify-terser": "0.80.10"
+    "metro": "0.81.0",
+    "metro-config": "0.81.0",
+    "metro-core": "0.81.0",
+    "metro-runtime": "0.81.0",
+    "metro-resolver": "0.81.0",
+    "metro-source-map": "0.81.0",
+    "metro-cache": "0.81.0",
+    "metro-minify-terser": "0.81.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin metro family packages to 0.81.0

## Testing
- `npm run lint`
- `npm test` *(fails: Unknown env config "http-proxy" and hangs; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689cee2dac94832cae4d09c6dc9a2e49