### PR TITLE
feat: sync push tokens with backend

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   passwordHash String
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  fcmToken     String?
 
   awards         Award[]
   dataExports    DataExport[]

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -17,6 +17,19 @@ await prisma.user.update({ where: { id: uid }, data: {} });
 return res.json({ ok: true });
 });
 
+profileRouter.post('/profile/push-token', requireAuth, async (req, res) => {
+const uid = (req as any).user.userId as string;
+const { token } = req.body || {};
+if (!token) return res.status(400).json({ error: 'Missing token' });
+try {
+await prisma.user.update({ where: { id: uid }, data: { fcmToken: token } });
+return res.json({ ok: true });
+} catch (err) {
+console.error('Error saving fcm token:', err);
+return res.status(500).json({ error: 'Failed to save token' });
+}
+});
+
 profileRouter.get('/profile/preferences', requireAuth, async (req, res) => {
 const uid = (req as any).user.userId as string;
 const prefs = await prisma.userPreference.findUnique({ where: { userId: uid } });


### PR DESCRIPTION
## Summary
- send push token to backend and retry until successful
- store push tokens on server via new endpoint and schema field

## Testing
- `npm run prisma-gen` *(fails: Failed to fetch sha256 checksum)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689d20408d7c832c8dc84a72b366884c