### PR TITLE
chore: add expo plugins and dev client docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,15 @@ npm run dev:emulators  # Firestore/Auth/CF
 npm run dev:expo       # Expo client against local emu
 ```
 
+## Custom Dev Client
+
+Generate native projects and build a custom development client:
+
+```bash
+npx expo prebuild
+npx expo run:android   # or npx expo run:ios
+```
+
 ## Push Notifications Setup
 
 1. Add your Firebase config files:
@@ -294,6 +303,7 @@ npm run dev:expo       # Expo client against local emu
 5. Send a test message from the Firebase console to verify foreground, background, and quit-state behavior.
 
 ## New Endpoints (Launch)
+
 - Recommendations: `GET /recommendations/for-you`, `GET /recommendations/related/:productId`
 - Reviews: `POST /products/:id/reviews`
 - Loyalty: `GET /loyalty/status`, `GET /loyalty/badges`

--- a/app.json
+++ b/app.json
@@ -17,6 +17,12 @@
       "backgroundColor": "#F9F9F9",
       "image": "./assets/splash/jars_splash_static.png",
       "resizeMode": "contain"
-    }
+    },
+    "plugins": [
+      "react-native-reanimated",
+      "@react-native-firebase/app",
+      "@react-native-firebase/messaging",
+      "@stripe/stripe-react-native"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add expo config plugins for reanimated, firebase app/messaging, and stripe
- document how to build a custom dev client

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: Cannot find module 'react-native')*
- `npx expo prebuild --no-install` *(fails: Package "react-native-reanimated" does not contain a valid config plugin)*
- `npx expo run:android --no-install` *(fails: Cannot find module 'metro/src/lib/TerminalReporter')*
- `npx expo run:ios --no-install` *(fails: Cannot find module 'metro/src/lib/TerminalReporter')*


------
https://chatgpt.com/codex/tasks/task_e_689d2039f4ec832c8647c17051572fe8