### PR TITLE
feat: add journal entry inputs and insights charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "8.4.1",
     "@react-native-community/netinfo": "^11.3.0",
+    "@react-native-community/slider": "^4.5.7",
     "@react-native-firebase/analytics": "^22.4.0",
     "@react-native-firebase/app": "^22.4.0",
     "@react-native-firebase/messaging": "^22.4.0",

--- a/src/screens/JournalEntryScreen.tsx
+++ b/src/screens/JournalEntryScreen.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TextInput } from 'react-native';
+import Slider from '@react-native-community/slider';
 import type { RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ThemeContext } from '../context/ThemeContext';
 import type { RootStackParamList } from '../navigation/types';
 import { hapticLight } from '../utils/haptic';
+import { addJournal } from '../api/phase4Client';
 
 const LABELS = ['Relaxation', 'Focus', 'Pain Relief', 'Creativity', 'Sleep'];
 
@@ -17,8 +19,34 @@ export default function JournalEntryScreen() {
   const navigation = useNavigation<NavProp>();
   const { jarsPrimary } = React.useContext(ThemeContext);
 
+  const [values, setValues] = React.useState(
+    LABELS.reduce<Record<string, number>>((acc, l) => ({ ...acc, [l]: 0 }), {})
+  );
+  const [notes, setNotes] = React.useState('');
+
+  const handleChange = (label: string, val: number) => {
+    setValues(v => ({ ...v, [label]: val }));
+  };
+
   const goBack = () => {
     hapticLight();
+    navigation.goBack();
+  };
+
+  const saveEntry = async () => {
+    hapticLight();
+    try {
+      const rating =
+        Object.values(values).reduce((a, b) => a + b, 0) / LABELS.length;
+      await addJournal({
+        productId: params.item.id,
+        rating,
+        notes,
+        tags: LABELS.filter(l => values[l] > 0),
+      });
+    } catch (e) {
+      // ignore
+    }
     navigation.goBack();
   };
 
@@ -26,14 +54,29 @@ export default function JournalEntryScreen() {
     <View style={styles.container}>
       <Text style={[styles.title, { color: jarsPrimary }]}>Journal Entry</Text>
       <Text style={styles.meta}>{params.item.name}</Text>
-      {/* Placeholder for sliders and notes */}
       {LABELS.map(label => (
         <View key={label} style={styles.sliderRow}>
-          <Text>{label}</Text>
+          <Text style={styles.sliderLabel}>{label}</Text>
+          <Slider
+            style={styles.slider}
+            minimumValue={0}
+            maximumValue={10}
+            step={1}
+            value={values[label]}
+            minimumTrackTintColor={jarsPrimary}
+            onValueChange={v => handleChange(label, v)}
+          />
+          <Text style={styles.sliderValue}>{values[label]}</Text>
         </View>
       ))}
-      <Text style={styles.placeholder}>Notes input coming soon...</Text>
-      <Text onPress={goBack} style={[styles.save, { color: jarsPrimary }]}>
+      <TextInput
+        placeholder="Notes"
+        value={notes}
+        onChangeText={setNotes}
+        multiline
+        style={styles.notes}
+      />
+      <Text onPress={saveEntry} style={[styles.save, { color: jarsPrimary }]}>
         Save
       </Text>
     </View>
@@ -44,7 +87,18 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
   title: { fontSize: 20, fontWeight: '600', marginBottom: 8 },
   meta: { fontSize: 16, marginBottom: 16 },
-  sliderRow: { height: 40, justifyContent: 'center' },
-  placeholder: { color: '#666', marginTop: 16 },
+  sliderRow: { flexDirection: 'row', alignItems: 'center', marginVertical: 8 },
+  sliderLabel: { width: 100 },
+  slider: { flex: 1, marginHorizontal: 8 },
+  sliderValue: { width: 24, textAlign: 'right' },
+  notes: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 8,
+    height: 80,
+    textAlignVertical: 'top',
+    marginTop: 16,
+  },
   save: { marginTop: 24, textAlign: 'right', fontSize: 16 },
 });

--- a/src/screens/MyJarsInsightsScreen.tsx
+++ b/src/screens/MyJarsInsightsScreen.tsx
@@ -1,13 +1,57 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import Svg, { Rect } from 'react-native-svg';
+import { getJournal } from '../api/phase4Client';
 import { ThemeContext } from '../context/ThemeContext';
 
 export default function MyJarsInsightsScreen() {
   const { jarsPrimary } = React.useContext(ThemeContext);
+  const { data, isLoading } = useQuery({ queryKey: ['journal'], queryFn: getJournal });
+
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  const entries = data ?? [];
+
+  if (entries.length === 0) {
+    return (
+      <View style={styles.container}>
+        <Text style={[styles.title, { color: jarsPrimary }]}>Insights</Text>
+        <Text style={styles.placeholder}>No journal data yet.</Text>
+      </View>
+    );
+  }
+
+  const counts = Array.from({ length: 11 }, (_, r) => ({
+    rating: r,
+    count: entries.filter((e: any) => Math.round(e.rating || 0) === r).length,
+  }));
+  const maxCount = Math.max(...counts.map(c => c.count), 1);
+  const chartWidth = 300;
+  const chartHeight = 160;
+  const barWidth = chartWidth / counts.length;
+
   return (
     <View style={styles.container}>
       <Text style={[styles.title, { color: jarsPrimary }]}>Insights</Text>
-      <Text style={styles.placeholder}>Charts coming soon...</Text>
+      <Svg width={chartWidth} height={chartHeight} style={styles.chart}>
+        {counts.map((d, i) => (
+          <Rect
+            key={d.rating}
+            x={i * barWidth}
+            y={chartHeight - (d.count / maxCount) * chartHeight}
+            width={barWidth - 4}
+            height={(d.count / maxCount) * chartHeight}
+            fill={jarsPrimary}
+          />
+        ))}
+      </Svg>
     </View>
   );
 }
@@ -16,4 +60,5 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
   title: { fontSize: 20, fontWeight: '600', marginBottom: 8 },
   placeholder: { color: '#666' },
+  chart: { marginTop: 16 },
 });


### PR DESCRIPTION
## Summary
- add mood/effect sliders and notes field for journal entries
- visualize journal ratings with a simple bar chart and empty state
- include slider dependency

## Testing
- `npm run lint` (fails: Cannot find module '@eslint/js')
- `npx tsc --noEmit` (fails: Cannot find type definition file for 'aws-lambda')


------
https://chatgpt.com/codex/tasks/task_e_689d26bf94fc832cba84dd84eb69ac52