### PR TITLE
feat: load home data from API

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -20,6 +20,7 @@ const recommendations_1 = require("./routes/recommendations");
 const data_1 = require("./routes/data");
 const concierge_1 = require("./routes/concierge");
 const ar_1 = require("./routes/ar");
+const home_1 = require("./routes/home");
 const firebase_admin_1 = require("./bootstrap/firebase-admin");
 const app = (0, express_1.default)();
 app.use(express_1.default.json({ limit: '1mb' }));
@@ -45,6 +46,7 @@ app.use('/api/v1', recommendations_1.recommendationsRouter);
 app.use('/api/v1', data_1.dataRouter);
 app.use('/api/v1', concierge_1.conciergeRouter);
 app.use('/api/v1', ar_1.arRouter);
+app.use('/api/v1', home_1.homeRouter);
 // Global error handler so nothing crashes
 app.use((err, _req, res, _next) => {
     console.error('Unhandled error:', err?.code || err?.message || err);

--- a/backend/dist/routes/home.js
+++ b/backend/dist/routes/home.js
@@ -1,0 +1,41 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.homeRouter = void 0;
+const express_1 = require("express");
+exports.homeRouter = (0, express_1.Router)();
+exports.homeRouter.get('/home/categories', (_req, res) => {
+    res.json([
+        { id: 'flower', label: 'Flower', emoji: '🌿' },
+        { id: 'vapes', label: 'Vapes', emoji: '💨' },
+        { id: 'edibles', label: 'Edibles', emoji: '🍪' },
+        { id: 'pre-rolls', label: 'Pre-rolls', emoji: '🚬' },
+        { id: 'concentrates', label: 'Concentrates', emoji: '🛢️' },
+        { id: 'gear', label: 'Gear', emoji: '🧰' },
+    ]);
+});
+exports.homeRouter.get('/home/featured', (_req, res) => {
+    res.json([
+        {
+            id: '1',
+            name: 'Rainbow Rozay',
+            price: 79.0,
+            image: 'https://via.placeholder.com/200',
+            description: 'A flavorful hybrid with fruity notes.',
+        },
+        {
+            id: '2',
+            name: 'Moonwalker OG',
+            price: 65.0,
+            image: 'https://via.placeholder.com/200',
+            description: 'Potent indica leaning strain for relaxation.',
+        },
+    ]);
+});
+exports.homeRouter.get('/home/ways', (_req, res) => {
+    res.json([
+        { id: 'deals', label: 'Shop Deals' },
+        { id: 'popular', label: 'Shop Popular' },
+        { id: 'effects', label: 'Shop Effects' },
+        { id: 'deli', label: 'Shop The Deli' },
+    ]);
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import { dataRouter } from './routes/data';
 import { conciergeRouter } from './routes/concierge';
 import { arRouter } from './routes/ar';
 import { qaRouter } from './routes/qa';
+import { homeRouter } from './routes/home';
 import { initFirebase } from './bootstrap/firebase-admin';
 
 const app = express();
@@ -42,6 +43,7 @@ app.use('/api/v1', recommendationsRouter);
 app.use('/api/v1', dataRouter);
 app.use('/api/v1', conciergeRouter);
 app.use('/api/v1', arRouter);
+app.use('/api/v1', homeRouter);
 if (process.env.DEBUG_DIAG === '1') app.use('/api/v1', qaRouter);
 
 // Global error handler so nothing crashes

--- a/backend/src/routes/home.ts
+++ b/backend/src/routes/home.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+
+export const homeRouter = Router();
+
+homeRouter.get('/home/categories', (_req, res) => {
+  res.json([
+    { id: 'flower', label: 'Flower', emoji: '🌿' },
+    { id: 'vapes', label: 'Vapes', emoji: '💨' },
+    { id: 'edibles', label: 'Edibles', emoji: '🍪' },
+    { id: 'pre-rolls', label: 'Pre-rolls', emoji: '🚬' },
+    { id: 'concentrates', label: 'Concentrates', emoji: '🛢️' },
+    { id: 'gear', label: 'Gear', emoji: '🧰' },
+  ]);
+});
+
+homeRouter.get('/home/featured', (_req, res) => {
+  res.json([
+    {
+      id: '1',
+      name: 'Rainbow Rozay',
+      price: 79.0,
+      image: 'https://via.placeholder.com/200',
+      description: 'A flavorful hybrid with fruity notes.',
+    },
+    {
+      id: '2',
+      name: 'Moonwalker OG',
+      price: 65.0,
+      image: 'https://via.placeholder.com/200',
+      description: 'Potent indica leaning strain for relaxation.',
+    },
+  ]);
+});
+
+homeRouter.get('/home/ways', (_req, res) => {
+  res.json([
+    { id: 'deals', label: 'Shop Deals' },
+    { id: 'popular', label: 'Shop Popular' },
+    { id: 'effects', label: 'Shop Effects' },
+    { id: 'deli', label: 'Shop The Deli' },
+  ]);
+});
+


### PR DESCRIPTION
## Summary
- add backend endpoints for home screen categories, featured items, and ways to shop
- load home screen sections from API with skeletons and empty-state handling

## Testing
- `npm run lint` *(fails: 168 problems - 5 errors, 163 warnings)*
- `npx tsc --noEmit` *(fails: module/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d295fd71c832ca8ca578cb10e12ed