### PR TITLE
Use env-based OpenWeather API key with fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14268,3 +14268,4 @@ FIREBASE_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQE
 # Stripe (replace with real credentials on launch)
 STRIPE_PUBLISHABLE_KEY=pk_test_xxx
 STRIPE_MERCHANT_ID=merchant.com.placeholder
+EXPO_PUBLIC_OPENWEATHER_KEY=


### PR DESCRIPTION
## Summary
- Load OpenWeather API key from environment instead of hardcoded constant
- Add `EXPO_PUBLIC_OPENWEATHER_KEY` to `.env.example`
- Fallback to time-based theming with warnings when key is missing or request fails

## Testing
- `npm run lint` *(fails: no-unused-vars, prettier/prettier)*
- `npx tsc --noEmit` *(fails: cannot find module 'react-native', implicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_689d2969b3a8832c9d4423ed8cb1789c