### PR TITLE
chore: sanitize Firebase config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,11 @@ npx expo run:android   # or npx expo run:ios
 
 1. Add your Firebase config files:
    - Place `google-services.json` in `android/app`.
-   - Place `GoogleService-Info.plist` in the iOS project.
+   - Place `GoogleService-Info.plist` in the iOS project. The repo contains a
+     placeholder with dummy keys; download the real file from the Firebase
+     console (Project settings → *General* → *Your apps*) or request it from a
+     maintainer and keep it out of version control. If a real key was
+     previously committed, rotate it in the Firebase console.
 2. **iOS:** Enable Push Notifications and Background Modes (Remote notifications) in Xcode. Upload your APNs key to Firebase.
 3. **Android:** Confirm `google-services.json` is present and Firebase Messaging is referenced in `AndroidManifest.xml`.
 4. On launch the app requests notification permission and logs the FCM token. Replace the sync stub in `App.tsx` to send the token to your backend if needed.

--- a/apps/ios/GoogleService-Info.plist
+++ b/apps/ios/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
     <key>API_KEY</key>
-    <string>AIzaSyAkOU1T4hBia3a7zjqLR2TMlIOam8H3Cms</string>
+    <string>REPLACE_WITH_API_KEY</string>
     <key>GCM_SENDER_ID</key>
-    <string>168461890531</string>
+    <string>REPLACE_WITH_GCM_SENDER_ID</string>
     <key>PLIST_VERSION</key>
     <string>1</string>
     <key>BUNDLE_ID</key>
-    <string>com.jarss.dev</string>
+    <string>REPLACE_WITH_BUNDLE_ID</string>
     <key>PROJECT_ID</key>
-    <string>jars-mobile-app</string>
+    <string>REPLACE_WITH_PROJECT_ID</string>
     <key>STORAGE_BUCKET</key>
-    <string>jars-mobile-app.firebasestorage.app</string>
+    <string>REPLACE_WITH_STORAGE_BUCKET</string>
     <key>IS_ADS_ENABLED</key>
     <false/>
     <key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
     <key>IS_SIGNIN_ENABLED</key>
     <true/>
     <key>GOOGLE_APP_ID</key>
-    <string>1:168461890531:ios:79bcd36f1a4ae7fad0a6d6</string>
+    <string>REPLACE_WITH_GOOGLE_APP_ID</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- replace committed Firebase iOS config with placeholders
- document how to retrieve real `GoogleService-Info.plist`

## Testing
- `./setup.sh`
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find module 'zustand')*


------
https://chatgpt.com/codex/tasks/task_e_689d2f2c1e50832c9e28113b45270fce