### PR TITLE
Fetch stash items and add MyJarsScreen test

### DIFF
--- a/src/api/phase4Client.ts
+++ b/src/api/phase4Client.ts
@@ -95,3 +95,8 @@ export async function getAwardsStatus() {
   const res = await phase4Client.get('/awards/status');
   return res.data;
 }
+
+export async function getStash() {
+  const res = await phase4Client.get('/stash');
+  return res.data;
+}

--- a/src/components/StashItemCard.tsx
+++ b/src/components/StashItemCard.tsx
@@ -7,7 +7,7 @@ import type { StashItem } from '../@types/jars';
 interface Props {
   item: StashItem;
   onJournal(): void;
-  onReorder(): void;
+  onReorder?(): void;
 }
 
 export default function StashItemCard({ item, onJournal, onReorder }: Props) {
@@ -16,8 +16,10 @@ export default function StashItemCard({ item, onJournal, onReorder }: Props) {
     onJournal();
   };
   const handleReorder = () => {
-    hapticLight();
-    onReorder();
+    if (onReorder) {
+      hapticLight();
+      onReorder();
+    }
   };
 
   return (
@@ -33,10 +35,12 @@ export default function StashItemCard({ item, onJournal, onReorder }: Props) {
           <BookOpen size={16} color="#2E5D46" />
           <Text style={styles.btnText}>Journal</Text>
         </Pressable>
-        <Pressable style={styles.btn} onPress={handleReorder}>
-          <ShoppingCart size={16} color="#2E5D46" />
-          <Text style={styles.btnText}>Reorder</Text>
-        </Pressable>
+        {onReorder && (
+          <Pressable style={styles.btn} onPress={handleReorder}>
+            <ShoppingCart size={16} color="#2E5D46" />
+            <Text style={styles.btnText}>Reorder</Text>
+          </Pressable>
+        )}
       </View>
     </View>
   );

--- a/src/screens/MyJarsScreen.tsx
+++ b/src/screens/MyJarsScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useState } from 'react';
-import { View, Text, FlatList, StyleSheet, Pressable } from 'react-native';
+import React, { useContext } from 'react';
+import { View, Text, FlatList, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { BarChart } from 'lucide-react-native';
@@ -8,23 +8,18 @@ import type { RootStackParamList } from '../navigation/types';
 import { ThemeContext } from '../context/ThemeContext';
 import { hapticLight } from '../utils/haptic';
 import type { StashItem } from '../@types/jars';
-
-const SAMPLE_ITEMS: StashItem[] = [
-  {
-    id: '1',
-    name: 'Blue Dream',
-    strainType: 'Hybrid',
-    purchaseDate: '2025-07-20',
-    status: 'in_stock',
-  },
-];
+import { useQuery } from '@tanstack/react-query';
+import { getStash } from '../api/phase4Client';
 
 type NavProp = NativeStackNavigationProp<RootStackParamList, 'MyJars'>;
 
 export default function MyJarsScreen() {
   const navigation = useNavigation<NavProp>();
   const { jarsPrimary } = useContext(ThemeContext);
-  const [items] = useState(SAMPLE_ITEMS);
+  const { data, isLoading } = useQuery<StashItem[]>({
+    queryKey: ['stash'],
+    queryFn: getStash,
+  });
 
   const openInsights = () => {
     hapticLight();
@@ -36,6 +31,14 @@ export default function MyJarsScreen() {
     navigation.navigate('JournalEntry', { item });
   };
 
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -45,11 +48,11 @@ export default function MyJarsScreen() {
         </Pressable>
       </View>
       <FlatList
-        data={items}
+        data={data ?? []}
         keyExtractor={i => i.id}
         contentContainerStyle={styles.list}
         renderItem={({ item }) => (
-          <StashItemCard item={item} onJournal={() => openJournal(item)} onReorder={() => {}} />
+          <StashItemCard item={item} onJournal={() => openJournal(item)} />
         )}
         ListEmptyComponent={
           <View style={styles.empty}>

--- a/tests/myJarsScreen.test.tsx
+++ b/tests/myJarsScreen.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { NavigationContainer } from '@react-navigation/native';
+import MyJarsScreen from '../src/screens/MyJarsScreen';
+import { ThemeContext } from '../src/context/ThemeContext';
+import { getStash } from '../src/api/phase4Client';
+import type { StashItem } from '../src/@types/jars';
+
+jest.mock('../src/api/phase4Client');
+
+describe('MyJarsScreen', () => {
+  it('renders fetched items', async () => {
+    const sample: StashItem[] = [
+      {
+        id: '1',
+        name: 'Blue Dream',
+        strainType: 'Hybrid',
+        purchaseDate: '2025-07-20',
+        status: 'in_stock',
+      },
+    ];
+    (getStash as jest.Mock).mockResolvedValue(sample);
+    const queryClient = new QueryClient();
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <NavigationContainer>
+          <ThemeContext.Provider
+            value={{
+              colorTemp: 'neutral',
+              jarsPrimary: '#2E5D46',
+              jarsSecondary: '#8CD24C',
+              jarsBackground: '#F9F9F9',
+              loading: false,
+            }}
+          >
+            <QueryClientProvider client={queryClient}>
+              <MyJarsScreen />
+            </QueryClientProvider>
+          </ThemeContext.Provider>
+        </NavigationContainer>
+      );
+    });
+    await act(async () => {});
+    expect(tree!.root.findAllByProps({ children: 'Blue Dream' }).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- fetch stash items from backend instead of sample data
- make stash card reorder action optional and hide button when unused
- add MyJarsScreen test confirming items render

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding types)*
- `npm test tests/myJarsScreen.test.tsx` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d3db610cc832c9080196b30109752