### PR TITLE
chore: ignore android google-services and add template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ backend/prisma/dev.db-journal
 service-account.json
 firebase_sa.b64
 assets/splash/jars_splash_static.png
+
+# Firebase Android config
+apps/android/google-services.json

--- a/README.md
+++ b/README.md
@@ -295,10 +295,12 @@ npx expo run:android   # or npx expo run:ios
 ## Push Notifications Setup
 
 1. Add your Firebase config files:
-   - Place `google-services.json` in `android/app`.
+   - Copy `apps/android/google-services.json.template` to
+     `apps/android/google-services.json` and replace the placeholders with your
+     project values before building. The real file is ignored by Git.
    - Place `GoogleService-Info.plist` in the iOS project. The repo contains a
      placeholder with dummy keys; download the real file from the Firebase
-     console (Project settings → *General* → *Your apps*) or request it from a
+     console (Project settings → _General_ → _Your apps_) or request it from a
      maintainer and keep it out of version control. If a real key was
      previously committed, rotate it in the Firebase console.
 2. **iOS:** Enable Push Notifications and Background Modes (Remote notifications) in Xcode. Upload your APNs key to Firebase.

--- a/apps/android/google-services.json.template
+++ b/apps/android/google-services.json.template
@@ -1,13 +1,13 @@
 {
   "project_info": {
-    "project_number": "168461890531",
-    "project_id": "jars-mobile-app",
-    "storage_bucket": "jars-mobile-app.firebasestorage.app"
+    "project_number": "YOUR_PROJECT_NUMBER",
+    "project_id": "YOUR_PROJECT_ID",
+    "storage_bucket": "YOUR_STORAGE_BUCKET"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:168461890531:android:365e036354ea48c9d0a6d6",
+        "mobilesdk_app_id": "YOUR_APP_ID",
         "android_client_info": {
           "package_name": "com.jars.dev.android"
         }
@@ -15,7 +15,7 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyBMfT2AAjc7nGgmT5YmCu6gvwm71hRT8fI"
+          "current_key": "YOUR_API_KEY"
         }
       ],
       "services": {


### PR DESCRIPTION
## Summary
- stop tracking android `google-services.json` and ignore the real file
- add placeholder `google-services.json.template`
- document how to supply Firebase config before building

## Testing
- `./setup.sh` (fails: npm ci requires updated lockfile)
- `npm run lint` (fails: 7 errors, 170 warnings)
- `npx tsc --noEmit` (fails: missing React Native modules)


------
https://chatgpt.com/codex/tasks/task_e_689d3da85490832cb2de86449e900e0d