### PR TITLE
chore: add babel config for reanimated

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['babel-preset-expo'],
+  plugins: ['react-native-reanimated/plugin'],
+};


### PR DESCRIPTION
## Summary
- configure Babel for Expo with Reanimated plugin

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run start` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e91312fc4832cb42f712305b00ad8