### PR TITLE
test: use react-native testing library

### DIFF
--- a/src/__tests__/deepLink.test.tsx
+++ b/src/__tests__/deepLink.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
 
 jest.mock('react-native', () => ({
   Linking: {

--- a/src/__tests__/useDataCategories.test.tsx
+++ b/src/__tests__/useDataCategories.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useDataCategories } from '../api/hooks/useDataCategories';
 import { phase4Client } from '../api/phase4Client';

--- a/src/__tests__/useLoyaltyStatus.test.tsx
+++ b/src/__tests__/useLoyaltyStatus.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useLoyaltyStatus } from '../api/hooks/useLoyaltyStatus';
 import { phase4Client } from '../api/phase4Client';

--- a/src/__tests__/usePrivacyPreferences.test.tsx
+++ b/src/__tests__/usePrivacyPreferences.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePrivacyPreferences } from '../api/hooks/usePrivacyPreferences';
 import { phase4Client } from '../api/phase4Client';

--- a/src/__tests__/useRedeemReward.test.tsx
+++ b/src/__tests__/useRedeemReward.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useRedeemReward } from '../api/hooks/useRedeemReward';
 import { phase4Client } from '../api/phase4Client';

--- a/src/__tests__/useUpdateUserProfile.test.tsx
+++ b/src/__tests__/useUpdateUserProfile.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUpdateUserProfile } from '../api/hooks/useUpdateUserProfile';
 import { phase4Client } from '../api/phase4Client';

--- a/src/__tests__/useUserProfile.test.tsx
+++ b/src/__tests__/useUserProfile.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUserProfile } from '../api/hooks/useUserProfile';
 import { phase4Client } from '../api/phase4Client';

--- a/tests/useCart.test.tsx
+++ b/tests/useCart.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { renderHook } from '@testing-library/react';
-import { waitFor } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import NetInfo from '@react-native-community/netinfo';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';


### PR DESCRIPTION
## Summary
- fix tests to import from react-native testing library

## Testing
- `npm run lint` (fails: 7 errors, 170 warnings)
- `npx tsc --noEmit`
- `npm test` (fails: cannot find module 'react-native' / '@testing-library/react-native')

------
https://chatgpt.com/codex/tasks/task_e_689eef156ab4832c841a08be801de062