### PR TITLE
Add Jest mocks for Expo modules

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -19,6 +19,9 @@ module.exports = {
   moduleNameMapper: {
     '\\.(svg)$': '<rootDir>/tests/__mocks__/svgMock.js',
     '\\.(png|jpg|jpeg|gif|webp)$': '<rootDir>/tests/__mocks__/svgMock.js',
+    '^expo$': '<rootDir>/tests/__mocks__/expo.js',
+    '^expo-linking$': '<rootDir>/tests/__mocks__/expo-linking.js',
+    '^expo-constants$': '<rootDir>/tests/__mocks__/expo-constants.js',
   },
   // Make sure TS/TSX are handled through Babel (via jest-expo preset)
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],

--- a/tests/__mocks__/expo-constants.js
+++ b/tests/__mocks__/expo-constants.js
@@ -1,0 +1,1 @@
+module.exports = { default: { manifest: {} } };

--- a/tests/__mocks__/expo-linking.js
+++ b/tests/__mocks__/expo-linking.js
@@ -1,0 +1,6 @@
+module.exports = {
+  addEventListener: () => ({ remove: () => {} }),
+  removeEventListener: () => {},
+  getInitialURL: () => Promise.resolve(null),
+  openURL: () => Promise.resolve(),
+};

--- a/tests/__mocks__/expo.js
+++ b/tests/__mocks__/expo.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
## Summary
- add basic mocks for Expo, Expo Linking, and Expo Constants
- map Expo modules to local mocks in Jest config

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-testing-library')*
- `npx tsc --noEmit`
- `npm test` *(fails: 22 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f910fbbe4832caabedbe35db4ff85