### PR TITLE
test: mock AsyncStorage and Expo modules in jest setup

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,18 @@
+jest.mock(
+  '@react-native-async-storage/async-storage',
+  () => require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+jest.mock('expo-haptics', () => ({
+  selectionAsync: jest.fn(),
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+}));
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
 // Built-in matchers for RTL (prefer new entry; fallback to deprecated jest-native)
 try {
   // RTL v12.4+ exposes this


### PR DESCRIPTION
## Summary
- mock `@react-native-async-storage/async-storage` using provided jest mock
- add light mocks for `expo-haptics` and `expo-secure-store`

## Testing
- `./setup.sh`
- `npm run lint` *(fails: 'jest' is not defined and others)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689f912d69ec832cbb7c534fdbd9b9db