### PR TITLE
chore: add jest globals to eslint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -59,6 +59,19 @@ module.exports = [
       jest,
       'testing-library': testingLibrary
     },
+    languageOptions: {
+      globals: {
+        jest: 'readonly',
+        describe: 'readonly',
+        test: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+      },
+    },
     rules: {
       'testing-library/no-unnecessary-act': 'off',
       'testing-library/no-await-sync-events': 'off'


### PR DESCRIPTION
## Summary
- allow Jest globals in test-specific ESLint override

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689f983fed68832c843b1ef8f9c66c1e