### PR TITLE
test: rely on global mocks

### DIFF
--- a/tests/onboarding.flow.test.tsx
+++ b/tests/onboarding.flow.test.tsx
@@ -6,9 +6,7 @@ import * as SecureStore from 'expo-secure-store';
 import { NavigationContainer } from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
 
-jest.mock('expo-secure-store');
 jest.mock('react-native-sound', () => jest.fn());
-jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
 
 it('marks onboarding complete on splash finish', () => {
   const tree = renderer.create(


### PR DESCRIPTION
## Summary
- remove local expo-secure-store and reanimated mocks from onboarding flow test so it uses global jest setup

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `npm test tests/onboarding.flow.test.tsx` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa79dcb14832cbb1b15ff210b46af