### PR TITLE
test: clear AsyncStorage before useCart tests

### DIFF
--- a/tests/useCart.test.tsx
+++ b/tests/useCart.test.tsx
@@ -11,6 +11,9 @@ jest.mock('../src/api/phase4Client');
 const queryClient = new QueryClient();
 
 describe('useCart', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
   it('returns cached cart when offline', async () => {
     (NetInfo.fetch as jest.Mock).mockResolvedValue({ isConnected: false });
     await AsyncStorage.setItem('cart', JSON.stringify({ items: [], total: 0 }));


### PR DESCRIPTION
## Summary
- ensure cart hook tests clear AsyncStorage before each run for isolation

## Testing
- `npm test tests/useCart.test.tsx` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa8dc4768832cb699902c9d9ab2cc