### PR TITLE
test: mock media files in jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -19,6 +19,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(svg)$': '<rootDir>/tests/__mocks__/svgMock.js',
     '\\.(png|jpg|jpeg|gif|webp)$': '<rootDir>/tests/__mocks__/svgMock.js',
+    '\\.(mp3|wav|mp4)$': '<rootDir>/tests/__mocks__/fileMock.js',
     '^expo$': '<rootDir>/tests/__mocks__/expo.js',
     '^expo-linking$': '<rootDir>/tests/__mocks__/expo-linking.js',
     '^expo-constants$': '<rootDir>/tests/__mocks__/expo-constants.js',

--- a/tests/__mocks__/fileMock.js
+++ b/tests/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = '';


### PR DESCRIPTION
## Summary
- mock MP3/WAV/MP4 files with empty string
- map media file extensions to mock in Jest config

## Testing
- `./setup.sh` *(fails: The `npm ci` command can only install with an existing package-lock.json)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_689fac8ba9bc832ca63e1c5127200f27