### PR TITLE
test: use global AsyncStorage mock

### DIFF
--- a/src/__tests__/cart/storePersistence.test.ts
+++ b/src/__tests__/cart/storePersistence.test.ts
@@ -1,10 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useCartStore, hydrateCartStore } from '../../../stores/useCartStore';
 
-jest.mock('@react-native-async-storage/async-storage', () =>
-  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
-);
-
 describe('cart store persistence', () => {
   beforeEach(async () => {
     await AsyncStorage.clear();

--- a/src/__tests__/locationWatcher.test.ts
+++ b/src/__tests__/locationWatcher.test.ts
@@ -3,15 +3,9 @@ import { logEvent } from '../utils/analytics';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 jest.mock('../utils/analytics');
-jest.mock('@react-native-async-storage/async-storage', () => {
-  let stored: Record<string, string | null> = {};
-  return {
-    getItem: jest.fn(key => Promise.resolve(stored[key] ?? null)),
-    setItem: jest.fn((key, value) => {
-      stored[key] = value;
-      return Promise.resolve();
-    }),
-  };
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
 });
 
 test('proximity alerts log once per day', async () => {


### PR DESCRIPTION
## Summary
- use repository-wide AsyncStorage mock in cart persistence tests
- rely on global AsyncStorage mock for proximity alert tests

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest', 'react', 'react-native')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb006d8d0832c975d7d3045e7fe1c