### PR TITLE
test: update secure store mocks

### DIFF
--- a/src/__tests__/deepLink.test.tsx
+++ b/src/__tests__/deepLink.test.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-undef */
 import React from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react-native';
+import * as SecureStore from 'expo-secure-store';
 
 jest.mock('react-native', () => ({
   Linking: {
@@ -22,21 +23,21 @@ jest.mock('../context/StoreContext', () => {
 import useDeepLinkHandler from '../hooks/useDeepLinkHandler';
 import { makeStore } from './testUtils';
 import { NavigationContainer } from '@react-navigation/native';
-jest.mock('expo-secure-store', () => ({
-  getItemAsync: jest.fn(() => Promise.resolve(null)),
-  setItemAsync: jest.fn(() => Promise.resolve()),
-  deleteItemAsync: jest.fn(() => Promise.resolve()),
-}));
 
 const { setPreferredStore } = require('../context/StoreContext') as any;
-const navigate = jest.fn();
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({ navigate }),
-}));
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: jest.fn() }),
+  };
+});
 
 beforeEach(() => {
   setPreferredStore.mockReset();
+  SecureStore.getItemAsync.mockResolvedValue(null);
+  SecureStore.setItemAsync.mockResolvedValue(undefined);
+  SecureStore.deleteItemAsync.mockResolvedValue(undefined);
 });
 
 test('deep link loads Shop with correct store', async () => {

--- a/src/__tests__/welcomeBanner.test.tsx
+++ b/src/__tests__/welcomeBanner.test.tsx
@@ -5,8 +5,10 @@ import renderer, { act } from 'react-test-renderer';
 import WelcomeBanner from '../components/WelcomeBanner';
 import { LoyaltyContext } from '../context/LoyaltyContext';
 import { makeStore } from './testUtils';
+import * as SecureStore from 'expo-secure-store';
 
 jest.mock('../context/StoreContext', () => {
+  const { makeStore } = require('./testUtils');
   let preferredStore = makeStore();
   const setPreferredStore = jest.fn();
   return {
@@ -23,17 +25,15 @@ jest.mock('react-native', () => ({
   Text: ({ children }: any) => <span>{children}</span>,
   StyleSheet: { create: () => ({}) },
 }));
-jest.mock('expo-secure-store', () => ({
-  getItemAsync: jest.fn(() => Promise.resolve(null)),
-  setItemAsync: jest.fn(() => Promise.resolve()),
-  deleteItemAsync: jest.fn(() => Promise.resolve()),
-}));
 
 const { __setPreferredStore, setPreferredStore } = require('../context/StoreContext') as any;
 
 beforeEach(() => {
   __setPreferredStore(makeStore());
   setPreferredStore.mockReset();
+  SecureStore.getItemAsync.mockResolvedValue(null);
+  SecureStore.setItemAsync.mockResolvedValue(undefined);
+  SecureStore.deleteItemAsync.mockResolvedValue(undefined);
 });
 
 it('shows default message when no promo', async () => {


### PR DESCRIPTION
## Summary
- refactor deepLink test to import expo-secure-store and configure mock via SecureStore
- refactor welcomeBanner test to configure SecureStore mock and require makeStore lazily

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test src/__tests__/deepLink.test.tsx src/__tests__/welcomeBanner.test.tsx` *(fails: ReferenceError: You are trying to `import` a file outside of the scope of the test code)*

------
https://chatgpt.com/codex/tasks/task_e_689fb004295c832c89def2cef53fcfaf