### PR TITLE
chore: point config to live backend

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -14,7 +14,7 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://api.example.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://api.jarscannabis.com"
       }
     }
   },

--- a/vercel.json
+++ b/vercel.json
@@ -4,12 +4,12 @@
   "buildCommand": "npm run vercel-build",
   "outputDirectory": "dist",
   "env": {
-    "EXPO_PUBLIC_API_BASE_URL": "https://api.example.com"
+    "EXPO_PUBLIC_API_BASE_URL": "https://api.jarscannabis.com"
   },
   "rewrites": [
     {
       "source": "/api/v1/(.*)",
-      "destination": "https://api.example.com/api/v1/$1"
+      "destination": "https://api.jarscannabis.com/api/v1/$1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- point Expo EAS production env at live backend URL
- update Vercel config env and rewrite to live backend

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_689fcf38a080832c9c5ba66251b325b5