### PR TITLE
docs: update support and license info

### DIFF
--- a/assets/app-store-info.md
+++ b/assets/app-store-info.md
@@ -6,7 +6,7 @@
 
 ## Support URL
 
-- https://example.com/support
+- https://help.jarsapp.com
 
 ## Compliance Info
 
@@ -14,4 +14,4 @@
 
 ## License Number
 
-- TBD
+- AU-R-000239


### PR DESCRIPTION
## Summary
- use production help URL in app store metadata
- document state license number

## Testing
- `./setup.sh` *(fails: EUSAGE The `npm ci` command can only install with an existing package-lock.json)*
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-import' / 972 problems)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689fcf350d1c832ca82ce204cab01f86