### PR TITLE
docs: add contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+We are committed to fostering a welcoming and harassment‑free community.
+
+## Our Standards
+
+- Be respectful and inclusive.
+- Accept constructive criticism with grace.
+- Focus on what is best for the community.
+
+## Enforcement
+
+Unacceptable behavior includes harassment, insults, or other conduct that would make anyone feel unwelcome.
+
+## Reporting
+
+If you experience or witness unacceptable behavior:
+
+- Open an issue describing the concern, **or**
+- Contact the maintainers privately at **support@jars.app**.
+
+All reports will be reviewed and addressed promptly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thanks for your interest in improving this project! Follow the steps below to get started.
+
+## Development Workflow
+
+1. Fork the repository and create your feature branch from `main`.
+2. Install dependencies and set up the project:
+   ```bash
+   chmod +x setup.sh
+   ./setup.sh
+   ```
+3. Make your changes and commit using descriptive messages.
+4. Run linting, type checks, and tests (see below) before submitting a pull request.
+5. Open a PR and describe your changes clearly.
+
+## Coding Standards
+
+- All code is written in **TypeScript**.
+- Ensure files pass **ESLint** and are formatted with **Prettier**.
+- Keep functions small and well‑documented.
+- Include or update tests when adding features or fixing bugs.
+
+## Running Tests
+
+Use the commands below to verify your changes:
+
+```bash
+npm run lint          # Run ESLint
+npx tsc --noEmit      # Type-check the project
+npm test              # Execute unit tests
+```
+
+Please make sure these commands succeed before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -319,3 +319,11 @@ npx expo run:android   # or npx expo run:ios
 - Preferences: `GET/PUT /profile/preferences`
 - Awards: `GET /awards/status`
 - Webhooks: `POST /webhook/stripe` (order status notifications)
+
+## Contributing
+
+We welcome improvements and bug fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, coding standards, and test instructions.
+
+## Code of Conduct
+
+Please read and follow our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) to help us maintain a respectful community.


### PR DESCRIPTION
## Summary
- add contributing guide with development workflow and testing instructions
- introduce project code of conduct
- link contribution and conduct docs from README

## Testing
- `npm run lint` *(fails: 311 errors, 677 warnings)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a10d855c80832cadd010d6843284bb