### PR TITLE
chore: clean up gitignore backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn.lock
 # Expo
 .expo/
 .expo-shared/
+web-build/
+android/
+ios/
 
 # macOS
 .DS_Store

--- a/.gitignore.backup
+++ b/.gitignore.backup
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
## Summary
- remove leftover `.gitignore.backup`
- add common Expo build directories to `.gitignore`

## Testing
- `./setup.sh` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68a10d903cac832ca88033a8f62df243