### PR TITLE
Enable Jest globals and clean up test lint rules

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -7,6 +7,7 @@ const reactNative = require('eslint-plugin-react-native');
 const importPlugin = require('eslint-plugin-import');
 const jest = require('eslint-plugin-jest');
 const testingLibrary = require('eslint-plugin-testing-library');
+const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
@@ -61,15 +62,8 @@ module.exports = [
     },
     languageOptions: {
       globals: {
-        jest: 'readonly',
-        describe: 'readonly',
-        test: 'readonly',
-        it: 'readonly',
-        expect: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        beforeAll: 'readonly',
-        afterAll: 'readonly',
+        ...globals.jest,
+        ...globals.node,
       },
     },
     rules: {

--- a/src/__tests__/deepLink.test.tsx
+++ b/src/__tests__/deepLink.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-env jest, node */
-/* eslint-disable no-undef */
 import React from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react-native';
 import * as SecureStore from 'expo-secure-store';

--- a/src/__tests__/welcomeBanner.test.tsx
+++ b/src/__tests__/welcomeBanner.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-env jest, node */
-/* eslint-disable no-undef */
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import WelcomeBanner from '../components/WelcomeBanner';


### PR DESCRIPTION
## Summary
- include `globals` for jest and node globals in test lint config
- drop `no-undef` disables from test files

## Testing
- `npm run lint` *(fails: Error: 'describe' is not defined in tests/firebase.e2e.ts, plus other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a125075190832c9700398c9745cd00