### PR TITLE
chore: enforce lint and format on vercel builds

### DIFF
--- a/vercel-build.sh
+++ b/vercel-build.sh
@@ -21,9 +21,9 @@ if [ -f "backend/prisma/schema.prisma" ]; then
   || echo "⚠️ Prisma generate skipped (no engine download available)"
 fi
 
-echo "🧹 Lint/format (non-blocking)…"
-npm run lint --if-present || true
-npm run format --if-present || true
+echo "🧹 Lint/format…"
+npm run lint --if-present
+npm run format --if-present
 
 echo "🏗️ Building…"
 npm run build


### PR DESCRIPTION
## Summary
- ensure lint/format failures stop Vercel builds

## Testing
- `./setup.sh` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68a12508f394832c81e7867a2b6340d1